### PR TITLE
Engine work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: clippy
         run: cargo clippy --features heif,av -- -D warnings
+
+      - name: test
+        run: cargo test --features heif,av

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,7 +618,6 @@ dependencies = [
  "libheif-rs",
  "nalgebra",
  "png 0.17.16",
- "psd",
  "rawler",
  "rayon",
  "resvg",
@@ -635,6 +634,8 @@ dependencies = [
  "xcf-rs",
  "zip",
  "zstd",
+ "zune-core 0.5.1",
+ "zune-psd",
 ]
 
 [[package]]
@@ -4523,15 +4524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psd"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a25f9b8cfffd65d911baf31a033239f7a0facb755faa2481575b70db5dc9195"
-dependencies = [
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7376,6 +7368,15 @@ name = "zune-jpeg"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core 0.5.1",
+]
+
+[[package]]
+name = "zune-psd"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a518b7a7bee76246a6c783d795c56204cd9184ce0e2e4483717f1b9438c902c"
 dependencies = [
  "zune-core 0.5.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,8 @@ rgb = "0.8.53"
 image-webp = "0.2.4"
 jxl-oxide = "0.12.5"
 jpeg2k = { version = "0.10.1", default-features = false, features = ["threads", "file-io", "openjpeg-sys"] }
-psd = "0.3.5"
+zune-psd = "0.5.1"
+zune-core = "0.5.1"
 icns = "0.4.0"
 dicom-object = "0.9.0"
 dicom-pixeldata = { version = "0.9.0", features = ["image", "openjpeg-sys"] }
@@ -105,6 +106,9 @@ av = ["dep:ffmpeg-next", "dep:cpal", "dep:ringbuf", "dep:crossbeam-channel"]
 winres = "0.1"
 
 [profile.release]
+# Small binary, but a panic in a third-party decoder aborts the app instead of
+# becoming a graceful load error. Fix: patch/replace the decoder, or drop abort
+# + catch_unwind in load_media.
 panic = "abort"
 codegen-units = 1
 lto = true

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -732,6 +732,10 @@ impl App {
             subs.push(every(Duration::from_millis(tick_ms)).map(Message::NotificationTick));
         }
 
+        if self.program.reprocess_pending() {
+            subs.push(every(Duration::from_millis(16)).map(|_| Message::Noop));
+        }
+
         Subscription::batch(subs)
     }
 }

--- a/src/components/modifier_stack.rs
+++ b/src/components/modifier_stack.rs
@@ -209,6 +209,17 @@ fn add_row<'a>() -> Element<'a, Message> {
                 )
                 .side(SubMenuSide::Left),
                 sub_menu(
+                    "Blur",
+                    styled_menu(
+                        column![menu_item(
+                            "Gaussian Blur",
+                            EditMsg::Add(ModifierType::GaussianBlur).into()
+                        ),],
+                        160
+                    )
+                )
+                .side(SubMenuSide::Left),
+                sub_menu(
                     "Stylize",
                     styled_menu(
                         column![
@@ -221,6 +232,17 @@ fn add_row<'a>() -> Element<'a, Message> {
                             menu_item("Threshold", EditMsg::Add(ModifierType::Threshold).into()),
                         ],
                         200
+                    )
+                )
+                .side(SubMenuSide::Left),
+                sub_menu(
+                    "Glitch",
+                    styled_menu(
+                        column![menu_item(
+                            "Pixel Sort",
+                            EditMsg::Add(ModifierType::PixelSort).into()
+                        ),],
+                        160
                     )
                 )
                 .side(SubMenuSide::Left),

--- a/src/export.rs
+++ b/src/export.rs
@@ -27,7 +27,7 @@ const STRIP_HEIGHT: u32 = 64;
 
 #[derive(Clone, Copy)]
 struct ExportCtx<'a> {
-    pixels: &'a [u8],
+    processed: &'a [u8],
     img_w: u32,
     img_h: u32,
     cx0: u32,
@@ -37,14 +37,22 @@ struct ExportCtx<'a> {
     out_w: u32,
     out_h: u32,
     rotation: u8,
-    modifiers: &'a [Modifier],
-    text_layers: &'a [Option<TextRaster>],
 }
 
-fn still_ctx<'a>(
-    data: &'a ExportData,
-    text_layers: &'a [Option<TextRaster>],
-) -> Result<ExportCtx<'a>, String> {
+#[derive(Clone, Copy)]
+struct Geom {
+    img_w: u32,
+    img_h: u32,
+    cx0: u32,
+    cy0: u32,
+    cw: u32,
+    ch: u32,
+    out_w: u32,
+    out_h: u32,
+    rotation: u8,
+}
+
+fn geom_of(data: &ExportData) -> Geom {
     let img_w = data.width;
     let img_h = data.height;
 
@@ -65,14 +73,7 @@ fn still_ctx<'a>(
         (ch, cw)
     };
 
-    let still = data
-        .frames
-        .get(data.still_index)
-        .ok_or_else(|| "No frame available.".to_string())?;
-    ensure_available(&still.pixels, img_w, img_h)?;
-
-    Ok(ExportCtx {
-        pixels: &still.pixels,
+    Geom {
         img_w,
         img_h,
         cx0,
@@ -82,14 +83,48 @@ fn still_ctx<'a>(
         out_w,
         out_h,
         rotation: data.rotation,
-        modifiers: &data.modifiers,
+    }
+}
+
+fn ctx_with<'a>(geom: &Geom, processed: &'a [u8]) -> ExportCtx<'a> {
+    ExportCtx {
+        processed,
+        img_w: geom.img_w,
+        img_h: geom.img_h,
+        cx0: geom.cx0,
+        cy0: geom.cy0,
+        cw: geom.cw,
+        ch: geom.ch,
+        out_w: geom.out_w,
+        out_h: geom.out_h,
+        rotation: geom.rotation,
+    }
+}
+
+fn process_frame(
+    data: &ExportData,
+    text_layers: &[Option<TextRaster>],
+    pixels: &[u8],
+) -> Result<Vec<u8>, String> {
+    ensure_available(pixels, data.width, data.height)?;
+    Ok(cpu::render_full(
+        &data.modifiers,
         text_layers,
-    })
+        pixels,
+        data.width,
+        data.height,
+    ))
 }
 
 pub fn render_still_rgba(data: &ExportData) -> Result<(u32, u32, Vec<u8>), String> {
     let text_layers = text_raster::build_layers(&data.modifiers, data.width, data.height);
-    let ctx = still_ctx(data, &text_layers)?;
+    let geom = geom_of(data);
+    let still = data
+        .frames
+        .get(data.still_index)
+        .ok_or_else(|| "No frame available.".to_string())?;
+    let processed = process_frame(data, &text_layers, &still.pixels)?;
+    let ctx = ctx_with(&geom, &processed);
     let mut rgba = vec![0u8; ctx.out_w as usize * ctx.out_h as usize * 4];
     render_into(&mut rgba, &ctx);
     Ok((ctx.out_w, ctx.out_h, rgba))
@@ -97,7 +132,7 @@ pub fn render_still_rgba(data: &ExportData) -> Result<(u32, u32, Vec<u8>), Strin
 
 pub fn do_export(data: ExportData, path: &Path, progress: impl Fn(f32)) -> Result<String, String> {
     let text_layers = text_raster::build_layers(&data.modifiers, data.width, data.height);
-    let ctx = still_ctx(&data, &text_layers)?;
+    let geom = geom_of(&data);
 
     let ext = path
         .extension()
@@ -106,11 +141,21 @@ pub fn do_export(data: ExportData, path: &Path, progress: impl Fn(f32)) -> Resul
         .to_ascii_lowercase();
 
     match ext.as_str() {
-        "gif" => encode_gif(&ctx, &data.frames, path, &progress)?,
-        "apng" => encode_apng(&ctx, &data.frames, path, &progress)?,
-        "jpg" | "jpeg" => encode_jpeg(&ctx, path, &progress)?,
-        "png" => encode_png(&ctx, path, &progress)?,
-        _ => encode_rgba(&ctx, path, &progress)?,
+        "gif" => encode_gif(&geom, &data, &text_layers, path, &progress)?,
+        "apng" => encode_apng(&geom, &data, &text_layers, path, &progress)?,
+        _ => {
+            let still = data
+                .frames
+                .get(data.still_index)
+                .ok_or_else(|| "No frame available.".to_string())?;
+            let processed = process_frame(&data, &text_layers, &still.pixels)?;
+            let ctx = ctx_with(&geom, &processed);
+            match ext.as_str() {
+                "jpg" | "jpeg" => encode_jpeg(&ctx, path, &progress)?,
+                "png" => encode_png(&ctx, path, &progress)?,
+                _ => encode_rgba(&ctx, path, &progress)?,
+            }
+        }
     }
 
     Ok(path
@@ -217,27 +262,26 @@ fn encode_jpeg(ctx: &ExportCtx, path: &Path, progress: &impl Fn(f32)) -> Result<
 }
 
 fn encode_apng(
-    ctx: &ExportCtx,
-    frames: &[ExportFrame],
+    geom: &Geom,
+    data: &ExportData,
+    text_layers: &[Option<TextRaster>],
     path: &Path,
     progress: &impl Fn(f32),
 ) -> Result<(), String> {
+    let frames = &data.frames;
     let file = std::fs::File::create(path).map_err(|e| e.to_string())?;
-    let mut enc = png::Encoder::new(BufWriter::new(file), ctx.out_w, ctx.out_h);
+    let mut enc = png::Encoder::new(BufWriter::new(file), geom.out_w, geom.out_h);
     enc.set_color(png::ColorType::Rgba);
     enc.set_depth(png::BitDepth::Eight);
     enc.set_animated(frames.len() as u32, 0)
         .map_err(|e| e.to_string())?;
     let mut writer = enc.write_header().map_err(|e| e.to_string())?;
 
-    let mut buf = vec![0u8; ctx.out_w as usize * ctx.out_h as usize * 4];
+    let mut buf = vec![0u8; geom.out_w as usize * geom.out_h as usize * 4];
     let n = frames.len();
     for (i, fr) in frames.iter().enumerate() {
-        ensure_available(&fr.pixels, ctx.img_w, ctx.img_h)?;
-        let fctx = ExportCtx {
-            pixels: &fr.pixels,
-            ..*ctx
-        };
+        let processed = process_frame(data, text_layers, &fr.pixels)?;
+        let fctx = ctx_with(geom, &processed);
         render_into(&mut buf, &fctx);
         let ms = (fr.delay.as_millis().min(u16::MAX as u128) as u16).max(1);
         writer
@@ -251,37 +295,36 @@ fn encode_apng(
 }
 
 fn encode_gif(
-    ctx: &ExportCtx,
-    frames: &[ExportFrame],
+    geom: &Geom,
+    data: &ExportData,
+    text_layers: &[Option<TextRaster>],
     path: &Path,
     progress: &impl Fn(f32),
 ) -> Result<(), String> {
-    if ctx.out_w > u16::MAX as u32 || ctx.out_h > u16::MAX as u32 {
+    if geom.out_w > u16::MAX as u32 || geom.out_h > u16::MAX as u32 {
         return Err("Image is too large for the GIF format (max 65535 px).".to_string());
     }
 
+    let frames = &data.frames;
     let file = std::fs::File::create(path).map_err(|e| e.to_string())?;
     let mut enc = gif::Encoder::new(
         BufWriter::new(file),
-        ctx.out_w as u16,
-        ctx.out_h as u16,
+        geom.out_w as u16,
+        geom.out_h as u16,
         &[],
     )
     .map_err(|e| e.to_string())?;
     enc.set_repeat(gif::Repeat::Infinite)
         .map_err(|e| e.to_string())?;
 
-    let mut buf = vec![0u8; ctx.out_w as usize * ctx.out_h as usize * 4];
+    let mut buf = vec![0u8; geom.out_w as usize * geom.out_h as usize * 4];
     let n = frames.len();
     for (i, fr) in frames.iter().enumerate() {
-        ensure_available(&fr.pixels, ctx.img_w, ctx.img_h)?;
-        let fctx = ExportCtx {
-            pixels: &fr.pixels,
-            ..*ctx
-        };
+        let processed = process_frame(data, text_layers, &fr.pixels)?;
+        let fctx = ctx_with(geom, &processed);
         render_into(&mut buf, &fctx);
         let mut frame =
-            gif::Frame::from_rgba_speed(ctx.out_w as u16, ctx.out_h as u16, &mut buf, 10);
+            gif::Frame::from_rgba_speed(geom.out_w as u16, geom.out_h as u16, &mut buf, 10);
         frame.delay = (fr.delay.as_millis() / 10).clamp(1, u16::MAX as u128) as u16;
         frame.dispose = gif::DisposalMethod::Background;
         enc.write_frame(&frame).map_err(|e| e.to_string())?;
@@ -311,21 +354,10 @@ fn fill_row(row: &mut [u8], oy: u32, ctx: &ExportCtx) {
         }
 
         let src = (fy as usize * ctx.img_w as usize + fx as usize) * 4;
-        let p = &ctx.pixels[src..src + 4];
-        let raw = cpu::pixel_to_f32(p);
-        let uv = [fx as f32 / ctx.img_w as f32, fy as f32 / ctx.img_h as f32];
-        let result = cpu::apply_modifiers_with_text(
-            ctx.modifiers,
-            ctx.text_layers,
-            ctx.pixels,
-            ctx.img_w,
-            ctx.img_h,
-            fx as f32 + 0.5,
-            fy as f32 + 0.5,
-            uv,
-            raw,
-        );
-        row[out..out + 4].copy_from_slice(&cpu::f32_to_pixel(result));
+        match ctx.processed.get(src..src + 4) {
+            Some(p) => row[out..out + 4].copy_from_slice(p),
+            None => row[out..out + 4].copy_from_slice(&[0, 0, 0, 0]),
+        }
     }
 }
 
@@ -432,6 +464,100 @@ mod tests {
         assert!(
             green_only < white,
             "text dominated by green fringe (green-only {green_only} vs white {white})"
+        );
+    }
+
+    #[test]
+    fn gaussian_blur_spreads_and_conserves_energy() {
+        use crate::modifiers::kinds::GaussianBlur;
+
+        let (w, h) = (64u32, 64u32);
+        let mut px = vec![0u8; (w * h * 4) as usize];
+        let cx = (h / 2 * w + w / 2) as usize * 4;
+        px[cx..cx + 4].copy_from_slice(&[255, 255, 255, 255]);
+        let pixels = Arc::new(px);
+
+        let data = ExportData {
+            frames: vec![ExportFrame {
+                pixels,
+                delay: Duration::ZERO,
+            }],
+            still_index: 0,
+            width: w,
+            height: h,
+            modifiers: vec![Modifier::new(ModifierKind::GaussianBlur(GaussianBlur {
+                radius: 4.0,
+            }))],
+            crop: None,
+            rotation: 0,
+        };
+
+        let (_, _, rgba) = render_still_rgba(&data).expect("render");
+
+        let center = rgba[cx];
+        let nonzero = rgba.chunks_exact(4).filter(|p| p[0] > 0).count();
+        assert!(center < 255, "blur should lower the peak (got {center})");
+        assert!(center > 0, "center should stay non-zero (got {center})");
+        assert!(
+            nonzero > 9,
+            "blur should spread to many pixels (got {nonzero})"
+        );
+    }
+
+    fn fnv1a(bytes: &[u8]) -> u64 {
+        let mut h = 0xcbf29ce484222325u64;
+        for &b in bytes {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x100000001b3);
+        }
+        h
+    }
+
+    fn gradient(w: u32, h: u32) -> Arc<Vec<u8>> {
+        let mut px = vec![0u8; (w * h * 4) as usize];
+        for y in 0..h {
+            for x in 0..w {
+                let o = ((y * w + x) * 4) as usize;
+                px[o] = (x * 255 / w.max(1)) as u8;
+                px[o + 1] = (y * 255 / h.max(1)) as u8;
+                px[o + 2] = ((x + y) * 255 / (w + h).max(1)) as u8;
+                px[o + 3] = 255;
+            }
+        }
+        Arc::new(px)
+    }
+
+    #[test]
+    fn mixed_chain_render_is_byte_stable() {
+        use crate::modifiers::kinds::{ChromaticAberration, Exposure, GaussianBlur, Posterize};
+
+        let (w, h) = (96u32, 72u32);
+        let data = ExportData {
+            frames: vec![ExportFrame {
+                pixels: gradient(w, h),
+                delay: Duration::ZERO,
+            }],
+            still_index: 0,
+            width: w,
+            height: h,
+            modifiers: vec![
+                Modifier::new(ModifierKind::Exposure(Exposure { exposure: 0.5 })),
+                Modifier::new(ModifierKind::GaussianBlur(GaussianBlur { radius: 3.0 })),
+                Modifier::new(ModifierKind::ChromaticAberration(ChromaticAberration {
+                    amount: 8.0,
+                })),
+                Modifier::new(ModifierKind::Posterize(Posterize { levels: 6 })),
+            ],
+            crop: None,
+            rotation: 0,
+        };
+
+        let (ow, oh, rgba) = render_still_rgba(&data).expect("render");
+        assert_eq!((ow, oh), (w, h));
+        assert_eq!(
+            fnv1a(&rgba),
+            0xb183c9457bb99f15,
+            "mixed-chain render output changed"
         );
     }
 }

--- a/src/modifiers/cpu.rs
+++ b/src/modifiers/cpu.rs
@@ -343,7 +343,7 @@ fn apply_prior(
                     c = blend_over(c, src);
                 }
             }
-            kind if !kind.input_request().is_pointwise() => {}
+            kind if !kind.effect_class().is_pointwise() => {}
             kind => {
                 c = kind.apply_cpu(img_w, img_h, uv, c);
             }

--- a/src/modifiers/cpu.rs
+++ b/src/modifiers/cpu.rs
@@ -1,5 +1,177 @@
+use rayon::prelude::*;
+
 use crate::modifiers::text_raster::TextRaster;
-use crate::modifiers::{InputClass, Modifier, ModifierKind};
+use crate::modifiers::{Modifier, ModifierKind};
+
+pub(crate) fn render_full(
+    modifiers: &[Modifier],
+    text_layers: &[Option<TextRaster>],
+    pixels: &[u8],
+    img_w: u32,
+    img_h: u32,
+) -> Vec<u8> {
+    let n = img_w as usize * img_h as usize * 4;
+    let mut cur = vec![0u8; n];
+    let copy = n.min(pixels.len());
+    cur[..copy].copy_from_slice(&pixels[..copy]);
+
+    let w = img_w as usize;
+    let h = img_h as usize;
+
+    let mut segment: Vec<&Modifier> = Vec::new();
+    let flush_segment = |cur: &mut [u8], segment: &mut Vec<&Modifier>| {
+        if segment.is_empty() {
+            return;
+        }
+        apply_pointwise_segment(cur, img_w, img_h, segment);
+        segment.clear();
+    };
+
+    for (i, m) in modifiers.iter().enumerate() {
+        if !m.has_visible_effect() {
+            continue;
+        }
+        match &m.kind {
+            ModifierKind::GaussianBlur(gb) => {
+                flush_segment(&mut cur, &mut segment);
+                blur_full(&mut cur, w, h, gb.radius);
+            }
+            ModifierKind::ChromaticAberration(ca) => {
+                flush_segment(&mut cur, &mut segment);
+                cur = chromatic_aberration_full(&cur, img_w, img_h, ca.amount);
+            }
+            ModifierKind::Text(_) => {
+                flush_segment(&mut cur, &mut segment);
+                if let Some(Some(raster)) = text_layers.get(i) {
+                    text_full(&mut cur, img_w, img_h, raster);
+                }
+            }
+            ModifierKind::PixelSort(ps) => {
+                flush_segment(&mut cur, &mut segment);
+                cur = crate::modifiers::pixel_sort::pixel_sort_cpu(
+                    &cur,
+                    w,
+                    h,
+                    ps.threshold,
+                    ps.angle,
+                );
+            }
+            _ => segment.push(m),
+        }
+    }
+    flush_segment(&mut cur, &mut segment);
+    cur
+}
+
+fn apply_pointwise_segment(buf: &mut [u8], img_w: u32, img_h: u32, segment: &[&Modifier]) {
+    let w = img_w as usize;
+    buf.par_chunks_mut(w * 4).enumerate().for_each(|(y, row)| {
+        let v = (y as f32 + 0.5) / img_h as f32;
+        for x in 0..w {
+            let o = x * 4;
+            let u = (x as f32 + 0.5) / img_w as f32;
+            let mut c = pixel_to_f32(&row[o..o + 4]);
+            for m in segment {
+                c = m.kind.apply_cpu(img_w, img_h, [u, v], c);
+            }
+            row[o..o + 4].copy_from_slice(&f32_to_pixel(c.map(|v| v.clamp(0.0, 1.0))));
+        }
+    });
+}
+
+fn blur_full(buf: &mut [u8], w: usize, h: usize, radius: f32) {
+    let r = radius.ceil() as i32;
+    if r <= 0 || w == 0 || h == 0 {
+        return;
+    }
+    let sigma = (radius / 3.0).max(0.5);
+    let inv = 1.0 / (2.0 * sigma * sigma);
+    let kernel: Vec<f32> = (-r..=r).map(|i| (-(i * i) as f32 * inv).exp()).collect();
+    let wsum: f32 = kernel.iter().sum();
+    let norm: Vec<f32> = kernel.iter().map(|k| k / wsum).collect();
+
+    let mut scratch = vec![0u8; buf.len()];
+    scratch
+        .par_chunks_mut(w * 4)
+        .zip(buf.par_chunks(w * 4))
+        .for_each(|(out_row, in_row)| {
+            for x in 0..w {
+                let mut acc = [0.0f32; 4];
+                for (ki, &k) in norm.iter().enumerate() {
+                    let sx = (x as i32 - r + ki as i32).clamp(0, w as i32 - 1) as usize;
+                    let o = sx * 4;
+                    acc[0] += in_row[o] as f32 * k;
+                    acc[1] += in_row[o + 1] as f32 * k;
+                    acc[2] += in_row[o + 2] as f32 * k;
+                    acc[3] += in_row[o + 3] as f32 * k;
+                }
+                let o = x * 4;
+                for c in 0..4 {
+                    out_row[o + c] = (acc[c] + 0.5).clamp(0.0, 255.0) as u8;
+                }
+            }
+        });
+    buf.par_chunks_mut(w * 4)
+        .enumerate()
+        .for_each(|(y, out_row)| {
+            for x in 0..w {
+                let mut acc = [0.0f32; 4];
+                for (ki, &k) in norm.iter().enumerate() {
+                    let sy = (y as i32 - r + ki as i32).clamp(0, h as i32 - 1) as usize;
+                    let o = (sy * w + x) * 4;
+                    acc[0] += scratch[o] as f32 * k;
+                    acc[1] += scratch[o + 1] as f32 * k;
+                    acc[2] += scratch[o + 2] as f32 * k;
+                    acc[3] += scratch[o + 3] as f32 * k;
+                }
+                let o = x * 4;
+                for c in 0..4 {
+                    out_row[o + c] = (acc[c] + 0.5).clamp(0.0, 255.0) as u8;
+                }
+            }
+        });
+}
+
+fn chromatic_aberration_full(src: &[u8], img_w: u32, img_h: u32, amount: f32) -> Vec<u8> {
+    let w = img_w as usize;
+    let scale = amount / img_w as f32;
+    let mut out = vec![0u8; src.len()];
+    out.par_chunks_mut(w * 4).enumerate().for_each(|(y, row)| {
+        let v = (y as f32 + 0.5) / img_h as f32;
+        for x in 0..w {
+            let u = (x as f32 + 0.5) / img_w as f32;
+            let r_uv = [
+                (u + (u - 0.5) * scale).clamp(0.0, 1.0),
+                (v + (v - 0.5) * scale).clamp(0.0, 1.0),
+            ];
+            let b_uv = [
+                (u - (u - 0.5) * scale).clamp(0.0, 1.0),
+                (v - (v - 0.5) * scale).clamp(0.0, 1.0),
+            ];
+            let cr = sample_pixel(src, img_w, img_h, r_uv[0], r_uv[1]);
+            let cg = sample_pixel(src, img_w, img_h, u, v);
+            let cb = sample_pixel(src, img_w, img_h, b_uv[0], b_uv[1]);
+            let o = x * 4;
+            row[o..o + 4].copy_from_slice(&f32_to_pixel([cr[0], cg[1], cb[2], cg[3]]));
+        }
+    });
+    out
+}
+
+fn text_full(buf: &mut [u8], img_w: u32, img_h: u32, raster: &TextRaster) {
+    let w = img_w as usize;
+    let _ = img_h;
+    buf.par_chunks_mut(w * 4).enumerate().for_each(|(y, row)| {
+        let fy = y as f32 + 0.5;
+        for x in 0..w {
+            if let Some(src) = raster.sample(x as f32 + 0.5, fy) {
+                let o = x * 4;
+                let dst = pixel_to_f32(&row[o..o + 4]);
+                row[o..o + 4].copy_from_slice(&f32_to_pixel(blend_over(dst, src)));
+            }
+        }
+    });
+}
 
 pub(crate) fn apply_modifiers(
     modifiers: &[Modifier],
@@ -59,6 +231,11 @@ pub(crate) fn apply_modifiers_with_text(
                 c[0] = cr[0];
                 c[2] = cb[2];
             }
+            ModifierKind::GaussianBlur(gb) => {
+                let prior = &modifiers[..i];
+                let prior_text = &text_layers[..i.min(text_layers.len())];
+                c = gaussian_blur_cpu(prior, prior_text, pixels, img_w, img_h, uv, gb.radius);
+            }
             ModifierKind::Text(_) => {
                 if let Some(Some(raster)) = text_layers.get(i)
                     && let Some(src) = raster.sample(fx, fy)
@@ -72,6 +249,60 @@ pub(crate) fn apply_modifiers_with_text(
         }
     }
     c.map(|v| v.clamp(0.0, 1.0))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn gaussian_blur_cpu(
+    prior: &[Modifier],
+    prior_text: &[Option<TextRaster>],
+    pixels: &[u8],
+    img_w: u32,
+    img_h: u32,
+    uv: [f32; 2],
+    radius: f32,
+) -> [f32; 4] {
+    let r = radius.ceil() as i32;
+    if r <= 0 {
+        return apply_prior(
+            prior,
+            prior_text,
+            img_w,
+            img_h,
+            uv,
+            sample_pixel(pixels, img_w, img_h, uv[0], uv[1]),
+        );
+    }
+    let sigma = (radius / 3.0).max(0.5);
+    let inv_two_sigma_sq = 1.0 / (2.0 * sigma * sigma);
+    let cx = uv[0] * img_w as f32;
+    let cy = uv[1] * img_h as f32;
+    let mut sum = [0.0f32; 4];
+    let mut weight_sum = 0.0f32;
+    for dy in -r..=r {
+        let wy = (-(dy * dy) as f32 * inv_two_sigma_sq).exp();
+        for dx in -r..=r {
+            let w = wy * (-(dx * dx) as f32 * inv_two_sigma_sq).exp();
+            let su = ((cx + dx as f32) / img_w as f32).clamp(0.0, 1.0);
+            let sv = ((cy + dy as f32) / img_h as f32).clamp(0.0, 1.0);
+            let tap = apply_prior(
+                prior,
+                prior_text,
+                img_w,
+                img_h,
+                [su, sv],
+                sample_pixel(pixels, img_w, img_h, su, sv),
+            );
+            for k in 0..4 {
+                sum[k] += tap[k] * w;
+            }
+            weight_sum += w;
+        }
+    }
+    if weight_sum > 0.0 {
+        sum.map(|v| v / weight_sum)
+    } else {
+        sum
+    }
 }
 
 fn blend_over(dst: [f32; 4], src: [f32; 4]) -> [f32; 4] {
@@ -112,7 +343,7 @@ fn apply_prior(
                     c = blend_over(c, src);
                 }
             }
-            kind if matches!(kind.input_class(), InputClass::NonPointwise) => {}
+            kind if !kind.input_request().is_pointwise() => {}
             kind => {
                 c = kind.apply_cpu(img_w, img_h, uv, c);
             }

--- a/src/modifiers/gpu.rs
+++ b/src/modifiers/gpu.rs
@@ -17,11 +17,23 @@ pub struct ModEntry {
     data: [[f32; 4]; 3],
 }
 
+#[derive(Clone, Copy)]
+pub struct UvRect {
+    pub origin: [f32; 2],
+    pub size: [f32; 2],
+}
+
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct ModUniforms {
     count: u32,
     _pad: [u32; 3],
+    proc_origin: [f32; 2],
+    proc_size: [f32; 2],
+    src_origin: [f32; 2],
+    src_size: [f32; 2],
+    full_size_px: [f32; 2],
+    _pad3: [f32; 2],
     entries: [ModEntry; 32],
 }
 
@@ -40,8 +52,18 @@ pub(crate) fn make_entry(kind: u32, params: &[f32]) -> ModEntry {
     e
 }
 
-pub fn build_segment_uniforms(segment: &[&Modifier], tile: &TileInfo) -> ModUniforms {
+pub fn build_segment_uniforms(
+    segment: &[&Modifier],
+    tile: &TileInfo,
+    proc: UvRect,
+    src: UvRect,
+) -> ModUniforms {
     let mut u = ModUniforms::zeroed();
+    u.proc_origin = proc.origin;
+    u.proc_size = proc.size;
+    u.src_origin = src.origin;
+    u.src_size = src.size;
+    u.full_size_px = [tile.full_w as f32, tile.full_h as f32];
     for m in segment {
         if u.count >= 32 {
             break;

--- a/src/modifiers/kinds/chromatic_aberration.rs
+++ b/src/modifiers/kinds/chromatic_aberration.rs
@@ -5,7 +5,7 @@ use iced::Element;
 use iced::widget::column;
 
 use crate::app::{EditMsg, Message};
-use crate::modifiers::{InputClass, ModifierImpl, ModifierParam};
+use crate::modifiers::{InputRequest, ModifierImpl, ModifierParam};
 use crate::widgets::value_slider::Fmt;
 
 use super::{finish, hash_f32, value_row};
@@ -30,8 +30,8 @@ impl ModifierImpl for ChromaticAberration {
         self.amount != 0.0
     }
 
-    fn input_class(&self) -> InputClass {
-        InputClass::NonPointwise
+    fn input_request(&self) -> InputRequest {
+        InputRequest::FullFrame
     }
 
     fn apply_param(&mut self, param: ModifierParam, _img_size: Option<(u32, u32)>) {

--- a/src/modifiers/kinds/gaussian_blur.rs
+++ b/src/modifiers/kinds/gaussian_blur.rs
@@ -5,10 +5,9 @@ use iced::Element;
 use iced::widget::column;
 
 use crate::app::{EditMsg, Message};
-use crate::modifiers::{ModifierImpl, ModifierParam};
-use crate::widgets::value_slider::Fmt;
+use crate::modifiers::{InputRequest, ModifierImpl, ModifierParam};
 
-use super::{finish, hash_f32, value_row};
+use super::{finish, hash_f32, number_row};
 
 #[derive(Debug, Clone)]
 pub struct GaussianBlur {
@@ -27,7 +26,13 @@ impl ModifierImpl for GaussianBlur {
     }
 
     fn has_effect(&self) -> bool {
-        false
+        self.radius > 0.0
+    }
+
+    fn input_request(&self) -> InputRequest {
+        InputRequest::Neighborhood {
+            radius_px: self.radius,
+        }
     }
 
     fn apply_param(&mut self, param: ModifierParam, _img_size: Option<(u32, u32)>) {
@@ -47,12 +52,12 @@ impl ModifierImpl for GaussianBlur {
         _image_size: Option<(u32, u32)>,
         _rotation: u8,
     ) -> Element<'_, Message> {
-        finish(column![value_row(
+        finish(column![number_row(
             "Radius",
             self.radius,
-            0.0..=100.0,
+            0.0,
             0.5,
-            Fmt::num(1),
+            "px",
             move |v| EditMsg::Update(index, ModifierParam::GaussianBlurRadius(v)).into(),
         )])
     }

--- a/src/modifiers/kinds/gaussian_blur.rs
+++ b/src/modifiers/kinds/gaussian_blur.rs
@@ -9,6 +9,8 @@ use crate::modifiers::{InputRequest, ModifierImpl, ModifierParam};
 
 use super::{finish, hash_f32, number_row};
 
+const MAX_RADIUS: f32 = 500.0;
+
 #[derive(Debug, Clone)]
 pub struct GaussianBlur {
     pub radius: f32,
@@ -37,7 +39,7 @@ impl ModifierImpl for GaussianBlur {
 
     fn apply_param(&mut self, param: ModifierParam, _img_size: Option<(u32, u32)>) {
         if let ModifierParam::GaussianBlurRadius(v) = param {
-            self.radius = v;
+            self.radius = v.clamp(0.0, MAX_RADIUS);
         }
     }
 

--- a/src/modifiers/kinds/grain.rs
+++ b/src/modifiers/kinds/grain.rs
@@ -54,17 +54,17 @@ impl ModifierImpl for Grain {
         }
     }
 
-    fn pack(&self, tile: &TileInfo) -> Option<ModEntry> {
+    fn pack(&self, _tile: &TileInfo) -> Option<ModEntry> {
         Some(make_entry(
             ids::GRAIN,
             &[
                 self.amount,
                 self.size,
                 self.seed,
-                tile.tile_x as f32,
-                tile.tile_y as f32,
-                tile.tile_w as f32,
-                tile.tile_h as f32,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
                 self.color,
                 self.response,
             ],

--- a/src/modifiers/kinds/halftone.rs
+++ b/src/modifiers/kinds/halftone.rs
@@ -46,10 +46,10 @@ impl ModifierImpl for Halftone {
             &[
                 self.size / tile.full_w.min(tile.full_h) as f32,
                 self.angle * PI / 180.0,
-                tile.tile_x as f32 / tile.full_w as f32,
-                tile.tile_y as f32 / tile.full_h as f32,
-                tile.tile_w as f32 / tile.full_w as f32,
-                tile.tile_h as f32 / tile.full_h as f32,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
                 self.size,
             ],
         ))

--- a/src/modifiers/kinds/mod.rs
+++ b/src/modifiers/kinds/mod.rs
@@ -48,6 +48,7 @@ use iced::{Element, Length};
 
 use crate::app::Message;
 use crate::widgets::angle_dial::AngleDial;
+use crate::widgets::number_entry::NumberEntry;
 use crate::widgets::value_slider::{Fmt, Track, ValueSlider};
 
 const LUMA: [f32; 3] = [0.2126, 0.7152, 0.0722];
@@ -81,6 +82,34 @@ fn value_row<'a>(
             .step(step)
             .format(fmt),
     ]
+    .align_y(Vertical::Center)
+    .spacing(4)
+    .into()
+}
+
+fn number_row<'a>(
+    label: &'a str,
+    value: f32,
+    min: f32,
+    step: f32,
+    suffix: &'static str,
+    on_change: impl Fn(f32) -> Message + 'static,
+) -> Element<'a, Message> {
+    row![
+        iced::widget::text(label)
+            .size(10)
+            .width(Length::Fixed(58.0))
+            .align_x(Horizontal::Left),
+        iced::widget::container(
+            NumberEntry::new(value, on_change)
+                .range(min, f32::INFINITY)
+                .step(step)
+                .suffix(suffix)
+                .width(70.0)
+        )
+        .center_x(Length::Fill),
+    ]
+    .width(Length::Fill)
     .align_y(Vertical::Center)
     .spacing(4)
     .into()

--- a/src/modifiers/kinds/pixel_sort.rs
+++ b/src/modifiers/kinds/pixel_sort.rs
@@ -5,7 +5,8 @@ use iced::Element;
 use iced::widget::column;
 
 use crate::app::{EditMsg, Message};
-use crate::modifiers::{ModifierImpl, ModifierParam};
+use crate::modifiers::pixel_sort::SortAxis;
+use crate::modifiers::{Axis, InputRequest, ModifierImpl, ModifierParam};
 use crate::widgets::value_slider::Fmt;
 
 use super::{angle_row, finish, hash_f32, value_row};
@@ -31,7 +32,15 @@ impl ModifierImpl for PixelSort {
     }
 
     fn has_effect(&self) -> bool {
-        false
+        self.threshold < 1.0
+    }
+
+    fn input_request(&self) -> InputRequest {
+        let axis = match SortAxis::from_angle(self.angle) {
+            SortAxis::Horizontal { .. } => Axis::Horizontal,
+            SortAxis::Vertical { .. } => Axis::Vertical,
+        };
+        InputRequest::ScanLines { axis }
     }
 
     fn apply_param(&mut self, param: ModifierParam, _img_size: Option<(u32, u32)>) {

--- a/src/modifiers/kinds/text.rs
+++ b/src/modifiers/kinds/text.rs
@@ -5,7 +5,7 @@ use iced::Element;
 use iced::widget::{column, text_input};
 
 use crate::app::{EditMsg, Message};
-use crate::modifiers::{InputClass, ModifierImpl, ModifierParam};
+use crate::modifiers::{InputRequest, ModifierImpl, ModifierParam};
 use crate::widgets::number_entry::NumberEntry;
 use crate::widgets::value_slider::Fmt;
 
@@ -104,8 +104,8 @@ impl ModifierImpl for Text {
         !self.content.is_empty() && self.opacity > 0.0
     }
 
-    fn input_class(&self) -> InputClass {
-        InputClass::NonPointwise
+    fn input_request(&self) -> InputRequest {
+        InputRequest::FullFrame
     }
 
     fn apply_param(&mut self, param: ModifierParam, _img_size: Option<(u32, u32)>) {

--- a/src/modifiers/kinds/vignette.rs
+++ b/src/modifiers/kinds/vignette.rs
@@ -46,18 +46,10 @@ impl ModifierImpl for Vignette {
         }
     }
 
-    fn pack(&self, tile: &TileInfo) -> Option<ModEntry> {
+    fn pack(&self, _tile: &TileInfo) -> Option<ModEntry> {
         Some(make_entry(
             ids::VIGNETTE,
-            &[
-                self.strength,
-                self.size,
-                self.softness,
-                tile.tile_x as f32 / tile.full_w as f32,
-                tile.tile_y as f32 / tile.full_h as f32,
-                tile.tile_w as f32 / tile.full_w as f32,
-                tile.tile_h as f32 / tile.full_h as f32,
-            ],
+            &[self.strength, self.size, self.softness],
         ))
     }
 

--- a/src/modifiers/mod.rs
+++ b/src/modifiers/mod.rs
@@ -7,6 +7,5 @@ pub mod text_render;
 mod types;
 
 pub use types::{
-    Axis, EffectClass, InputRequest, Modifier, ModifierImpl, ModifierKind, ModifierParam,
-    ModifierType, ids,
+    Axis, InputRequest, Modifier, ModifierImpl, ModifierKind, ModifierParam, ModifierType, ids,
 };

--- a/src/modifiers/mod.rs
+++ b/src/modifiers/mod.rs
@@ -1,10 +1,11 @@
 pub mod cpu;
 pub mod gpu;
 pub mod kinds;
+pub mod pixel_sort;
 pub mod text_raster;
 pub mod text_render;
 mod types;
 
 pub use types::{
-    InputClass, Modifier, ModifierImpl, ModifierKind, ModifierParam, ModifierType, ids,
+    Axis, InputRequest, Modifier, ModifierImpl, ModifierKind, ModifierParam, ModifierType, ids,
 };

--- a/src/modifiers/mod.rs
+++ b/src/modifiers/mod.rs
@@ -7,5 +7,6 @@ pub mod text_render;
 mod types;
 
 pub use types::{
-    Axis, InputRequest, Modifier, ModifierImpl, ModifierKind, ModifierParam, ModifierType, ids,
+    Axis, EffectClass, InputRequest, Modifier, ModifierImpl, ModifierKind, ModifierParam,
+    ModifierType, ids,
 };

--- a/src/modifiers/pixel_sort.rs
+++ b/src/modifiers/pixel_sort.rs
@@ -16,6 +16,89 @@ impl SortAxis {
     }
 }
 
+const RATIONAL_SLOPES: [(i32, i32); 4] = [(1, 1), (1, 2), (2, 1), (1, 3)];
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SortMode {
+    Cardinal(SortAxis),
+    Diagonal { dx: i32, dy: i32 },
+}
+
+impl SortMode {
+    pub fn from_angle(angle: f32) -> Self {
+        let a = angle.rem_euclid(360.0);
+        if (a % 90.0).min(90.0 - (a % 90.0)) <= 1.0 {
+            return SortMode::Cardinal(SortAxis::from_angle(angle));
+        }
+        let target = a.to_radians();
+        let (mut best, mut best_err) = ((1i32, 1i32), f32::INFINITY);
+        for &(p, q) in &RATIONAL_SLOPES {
+            for &(sx, sy) in &[(1, 1), (-1, 1), (1, -1), (-1, -1)] {
+                for &(dx, dy) in &[(p * sx, q * sy), (q * sx, p * sy)] {
+                    let err = angle_diff(target, (dy as f32).atan2(dx as f32));
+                    if err < best_err {
+                        best_err = err;
+                        best = (dx, dy);
+                    }
+                }
+            }
+        }
+        SortMode::Diagonal {
+            dx: best.0,
+            dy: best.1,
+        }
+    }
+}
+
+fn angle_diff(a: f32, b: f32) -> f32 {
+    let d = (a - b).rem_euclid(std::f32::consts::TAU);
+    d.min(std::f32::consts::TAU - d)
+}
+
+pub fn diagonal_lines(width: usize, height: usize, dx: i32, dy: i32) -> Vec<Vec<usize>> {
+    if width == 0 || height == 0 {
+        return Vec::new();
+    }
+    let g = gcd(dx.unsigned_abs(), dy.unsigned_abs()).max(1) as i32;
+    let (dx, dy) = (dx / g, dy / g);
+
+    let (w, h) = (width as i32, height as i32);
+    let corners = [0, dy * (w - 1), -dx * (h - 1), dy * (w - 1) - dx * (h - 1)];
+    let cross_min = *corners.iter().min().unwrap();
+    let cross_max = *corners.iter().max().unwrap();
+    let span = (cross_max - cross_min + 1) as usize;
+
+    let mut bucket_of = vec![usize::MAX; span];
+    let mut lines: Vec<Vec<usize>> = Vec::new();
+    for y in 0..height {
+        for x in 0..width {
+            let slot = (dy * x as i32 - dx * y as i32 - cross_min) as usize;
+            let bucket = match bucket_of[slot] {
+                usize::MAX => {
+                    let b = lines.len();
+                    bucket_of[slot] = b;
+                    lines.push(Vec::new());
+                    b
+                }
+                b => b,
+            };
+            lines[bucket].push(y * width + x);
+        }
+    }
+
+    for line in &mut lines {
+        line.sort_by_key(|&idx| {
+            let (x, y) = ((idx % width) as i32, (idx / width) as i32);
+            dx * x + dy * y
+        });
+    }
+    lines
+}
+
+fn gcd(a: u32, b: u32) -> u32 {
+    if b == 0 { a } else { gcd(b, a % b) }
+}
+
 pub fn key_of(p: &[u8]) -> u8 {
     let y = 0.2126 * p[0] as f32 + 0.7152 * p[1] as f32 + 0.0722 * p[2] as f32;
     (y + 0.5).clamp(0.0, 255.0) as u8
@@ -83,17 +166,22 @@ pub fn pixel_sort_cpu(
 ) -> Vec<u8> {
     let mut out = src.to_vec();
     let cutoff = key_cutoff(threshold);
-    match SortAxis::from_angle(angle) {
-        SortAxis::Horizontal { reverse } => {
+    match SortMode::from_angle(angle) {
+        SortMode::Cardinal(SortAxis::Horizontal { reverse }) => {
             for y in 0..height {
                 let idx: Vec<usize> = (0..width).map(|x| y * width + x).collect();
                 sort_line(&mut out, &idx, cutoff, reverse);
             }
         }
-        SortAxis::Vertical { reverse } => {
+        SortMode::Cardinal(SortAxis::Vertical { reverse }) => {
             for x in 0..width {
                 let idx: Vec<usize> = (0..height).map(|y| y * width + x).collect();
                 sort_line(&mut out, &idx, cutoff, reverse);
+            }
+        }
+        SortMode::Diagonal { dx, dy } => {
+            for idx in diagonal_lines(width, height, dx, dy) {
+                sort_line(&mut out, &idx, cutoff, false);
             }
         }
     }
@@ -150,5 +238,95 @@ mod tests {
         let out = pixel_sort_cpu(&src, 1, 3, 0.0, 90.0);
         let vals: Vec<u8> = (0..3).map(|y| out[y * 4]).collect();
         assert_eq!(vals, vec![50, 100, 150]);
+    }
+
+    fn assert_partition(width: usize, height: usize, dx: i32, dy: i32) {
+        let lines = diagonal_lines(width, height, dx, dy);
+        let mut seen = vec![0u32; width * height];
+        for line in &lines {
+            for &idx in line {
+                seen[idx] += 1;
+            }
+        }
+        assert!(
+            seen.iter().all(|&c| c == 1),
+            "diagonal_lines({width}x{height}, {dx},{dy}) is not a partition: {:?}",
+            seen.iter()
+                .enumerate()
+                .filter(|&(_, &c)| c != 1)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn diagonal_lines_partition_all_pixels() {
+        for &(w, h) in &[(1, 1), (4, 4), (5, 3), (3, 5), (7, 11), (16, 9)] {
+            for &(dx, dy) in &[
+                (1, 1),
+                (1, -1),
+                (-1, 1),
+                (2, 1),
+                (1, 2),
+                (3, 1),
+                (1, 3),
+                (2, 4),
+            ] {
+                assert_partition(w, h, dx, dy);
+            }
+        }
+    }
+
+    #[test]
+    fn diagonal_lines_within_line_follow_direction() {
+        let lines = diagonal_lines(3, 3, 1, 1);
+        let main: Vec<usize> = lines
+            .iter()
+            .find(|l| l.contains(&0) && l.len() == 3)
+            .expect("main diagonal present")
+            .clone();
+        assert_eq!(main, vec![0, 4, 8]);
+    }
+
+    #[test]
+    fn diagonal_lines_reduces_slope_by_gcd() {
+        let a = diagonal_lines(6, 6, 2, 2);
+        let b = diagonal_lines(6, 6, 1, 1);
+        assert_eq!(a, b, "(2,2) must reduce to (1,1)");
+    }
+
+    #[test]
+    fn from_angle_snaps_cardinal_and_picks_diagonal() {
+        assert!(matches!(SortMode::from_angle(0.0), SortMode::Cardinal(_)));
+        assert!(matches!(SortMode::from_angle(90.5), SortMode::Cardinal(_)));
+        assert!(matches!(
+            SortMode::from_angle(45.0),
+            SortMode::Diagonal { .. }
+        ));
+        if let SortMode::Diagonal { dx, dy } = SortMode::from_angle(45.0) {
+            assert_eq!((dx.abs(), dy.abs()), (1, 1));
+        }
+    }
+
+    #[test]
+    fn diagonal_sort_orders_main_diagonal() {
+        let g = |v: u8| [v, v, v, 255u8];
+        let mut src = Vec::new();
+        for v in [
+            90u8, 10, 10, //
+            10, 60, 10, //
+            10, 10, 30,
+        ] {
+            src.extend_from_slice(&g(v));
+        }
+        let out = pixel_sort_cpu(&src, 3, 3, 0.0, 45.0);
+        let diag: Vec<u8> = [0usize, 4, 8].iter().map(|&i| out[i * 4]).collect();
+        assert_eq!(diag, vec![30, 60, 90]);
+        for &off in &[1usize, 2, 3, 5, 6, 7] {
+            assert_eq!(
+                out[off * 4],
+                10,
+                "off-diagonal pixel {off} must be unchanged"
+            );
+        }
     }
 }

--- a/src/modifiers/pixel_sort.rs
+++ b/src/modifiers/pixel_sort.rs
@@ -57,44 +57,43 @@ fn angle_diff(a: f32, b: f32) -> f32 {
     d.min(std::f32::consts::TAU - d)
 }
 
-pub fn diagonal_lines(width: usize, height: usize, dx: i32, dy: i32) -> Vec<Vec<usize>> {
-    if width == 0 || height == 0 {
-        return Vec::new();
-    }
+pub fn reduced_step(dx: i32, dy: i32) -> (i32, i32) {
     let g = gcd(dx.unsigned_abs(), dy.unsigned_abs()).max(1) as i32;
-    let (dx, dy) = (dx / g, dy / g);
+    (dx / g, dy / g)
+}
 
+fn for_each_diagonal_line(
+    width: usize,
+    height: usize,
+    dx: i32,
+    dy: i32,
+    mut f: impl FnMut(&[usize]),
+) {
+    if width == 0 || height == 0 {
+        return;
+    }
+    let (dx, dy) = reduced_step(dx, dy);
+    if dx == 0 && dy == 0 {
+        return;
+    }
     let (w, h) = (width as i32, height as i32);
-    let corners = [0, dy * (w - 1), -dx * (h - 1), dy * (w - 1) - dx * (h - 1)];
-    let cross_min = *corners.iter().min().unwrap();
-    let cross_max = *corners.iter().max().unwrap();
-    let span = (cross_max - cross_min + 1) as usize;
-
-    let mut bucket_of = vec![usize::MAX; span];
-    let mut lines: Vec<Vec<usize>> = Vec::new();
-    for y in 0..height {
-        for x in 0..width {
-            let slot = (dy * x as i32 - dx * y as i32 - cross_min) as usize;
-            let bucket = match bucket_of[slot] {
-                usize::MAX => {
-                    let b = lines.len();
-                    bucket_of[slot] = b;
-                    lines.push(Vec::new());
-                    b
-                }
-                b => b,
-            };
-            lines[bucket].push(y * width + x);
+    let in_bounds = |x: i32, y: i32| x >= 0 && x < w && y >= 0 && y < h;
+    let mut line: Vec<usize> = Vec::new();
+    for y0 in 0..h {
+        for x0 in 0..w {
+            if in_bounds(x0 - dx, y0 - dy) {
+                continue;
+            }
+            line.clear();
+            let (mut x, mut y) = (x0, y0);
+            while in_bounds(x, y) {
+                line.push((y * w + x) as usize);
+                x += dx;
+                y += dy;
+            }
+            f(&line);
         }
     }
-
-    for line in &mut lines {
-        line.sort_by_key(|&idx| {
-            let (x, y) = ((idx % width) as i32, (idx / width) as i32);
-            dx * x + dy * y
-        });
-    }
-    lines
 }
 
 fn gcd(a: u32, b: u32) -> u32 {
@@ -155,13 +154,11 @@ fn sort_row(row: &mut [Rgba], cutoff: u8, reverse: bool, sorted: &mut Vec<Rgba>)
 
 fn transpose(src: &[Rgba], width: usize, height: usize) -> Vec<Rgba> {
     let mut out = vec![Rgba::default(); src.len()];
-    out.par_chunks_mut(height)
-        .enumerate()
-        .for_each(|(x, col)| {
-            for (y, dst) in col.iter_mut().enumerate() {
-                *dst = src[y * width + x];
-            }
-        });
+    out.par_chunks_mut(height).enumerate().for_each(|(x, col)| {
+        for (y, dst) in col.iter_mut().enumerate() {
+            *dst = src[y * width + x];
+        }
+    });
     out
 }
 
@@ -180,32 +177,33 @@ pub fn pixel_sort_cpu(
     match SortMode::from_angle(angle) {
         SortMode::Cardinal(SortAxis::Horizontal { reverse }) => {
             let px: &mut [Rgba] = bytemuck::cast_slice_mut(&mut out);
-            px.par_chunks_mut(width).for_each_init(Vec::new, |scratch, row| {
-                sort_row(row, cutoff, reverse, scratch);
-            });
+            px.par_chunks_mut(width)
+                .for_each_init(Vec::new, |scratch, row| {
+                    sort_row(row, cutoff, reverse, scratch);
+                });
         }
         SortMode::Cardinal(SortAxis::Vertical { reverse }) => {
             let px: &[Rgba] = bytemuck::cast_slice(&out);
             let mut t = transpose(px, width, height);
-            t.par_chunks_mut(height).for_each_init(Vec::new, |scratch, col| {
-                sort_row(col, cutoff, reverse, scratch);
-            });
+            t.par_chunks_mut(height)
+                .for_each_init(Vec::new, |scratch, col| {
+                    sort_row(col, cutoff, reverse, scratch);
+                });
             let back = transpose(&t, height, width);
             out.copy_from_slice(bytemuck::cast_slice(&back));
         }
         SortMode::Diagonal { dx, dy } => {
-            let lines = diagonal_lines(width, height, dx, dy);
             let px: &mut [Rgba] = bytemuck::cast_slice_mut(&mut out);
             let mut gather: Vec<Rgba> = Vec::new();
             let mut scratch: Vec<Rgba> = Vec::new();
-            for idx in &lines {
+            for_each_diagonal_line(width, height, dx, dy, |idx| {
                 gather.clear();
                 gather.extend(idx.iter().map(|&i| px[i]));
                 sort_row(&mut gather, cutoff, false, &mut scratch);
                 for (&i, &p) in idx.iter().zip(gather.iter()) {
                     px[i] = p;
                 }
-            }
+            });
         }
     }
     out
@@ -282,6 +280,12 @@ mod tests {
         let out = pixel_sort_cpu(&src, 1, 3, 0.0, 90.0);
         let vals: Vec<u8> = (0..3).map(|y| out[y * 4]).collect();
         assert_eq!(vals, vec![50, 100, 150]);
+    }
+
+    fn diagonal_lines(width: usize, height: usize, dx: i32, dy: i32) -> Vec<Vec<usize>> {
+        let mut lines = Vec::new();
+        for_each_diagonal_line(width, height, dx, dy, |l| lines.push(l.to_vec()));
+        lines
     }
 
     fn assert_partition(width: usize, height: usize, dx: i32, dy: i32) {
@@ -374,7 +378,14 @@ mod tests {
         }
     }
 
-    fn reference_sort(src: &[u8], w: usize, h: usize, cutoff: u8, vertical: bool, reverse: bool) -> Vec<u8> {
+    fn reference_sort(
+        src: &[u8],
+        w: usize,
+        h: usize,
+        cutoff: u8,
+        vertical: bool,
+        reverse: bool,
+    ) -> Vec<u8> {
         let mut out = src.to_vec();
         let line = |k: usize| -> Vec<usize> {
             if vertical {
@@ -430,15 +441,15 @@ mod tests {
             let src: Vec<u8> = (0..w * h * 4).map(|_| rng()).collect();
             for &thr in &[0.0f32, 0.3, 0.6] {
                 let cutoff = key_cutoff(thr);
-                for &(angle, vertical, reverse) in
-                    &[(0.0f32, false, false), (180.0, false, true), (90.0, true, false), (270.0, true, true)]
-                {
+                for &(angle, vertical, reverse) in &[
+                    (0.0f32, false, false),
+                    (180.0, false, true),
+                    (90.0, true, false),
+                    (270.0, true, true),
+                ] {
                     let got = pixel_sort_cpu(&src, w, h, thr, angle);
                     let want = reference_sort(&src, w, h, cutoff, vertical, reverse);
-                    assert_eq!(
-                        got, want,
-                        "mismatch at {w}x{h} thr={thr} angle={angle}"
-                    );
+                    assert_eq!(got, want, "mismatch at {w}x{h} thr={thr} angle={angle}");
                 }
             }
         }
@@ -458,7 +469,11 @@ mod tests {
         };
         let src: Vec<u8> = (0..w * h * 4).map(|_| rng()).collect();
 
-        for &(label, angle) in &[("horizontal", 0.0f32), ("vertical", 90.0), ("diagonal", 45.0)] {
+        for &(label, angle) in &[
+            ("horizontal", 0.0f32),
+            ("vertical", 90.0),
+            ("diagonal", 45.0),
+        ] {
             let t = Instant::now();
             let out = pixel_sort_cpu(&src, w, h, 0.3, angle);
             let ms = t.elapsed().as_secs_f64() * 1000.0;

--- a/src/modifiers/pixel_sort.rs
+++ b/src/modifiers/pixel_sort.rs
@@ -1,3 +1,5 @@
+use rayon::prelude::*;
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SortAxis {
     Horizontal { reverse: bool },
@@ -108,53 +110,59 @@ pub fn key_cutoff(threshold: f32) -> u8 {
     (threshold * 255.0 + 0.5).clamp(0.0, 255.0) as u8
 }
 
-fn sort_line(pixels: &mut [u8], idx: &[usize], cutoff: u8, reverse: bool) {
-    let n = idx.len();
+type Rgba = [u8; 4];
+
+fn counting_sort_run(run: &mut [Rgba], reverse: bool, sorted: &mut Vec<Rgba>) {
+    let mut count = [0u32; 256];
+    for px in run.iter() {
+        count[key_of(px) as usize] += 1;
+    }
+    let mut offset = [0u32; 256];
+    let mut acc = 0u32;
+    for b in 0..256 {
+        offset[b] = acc;
+        acc += count[b];
+    }
+
+    let n = run.len() as u32;
+    sorted.clear();
+    sorted.resize(run.len(), Rgba::default());
+    for px in run.iter() {
+        let k = key_of(px) as usize;
+        let dst = offset[k];
+        offset[k] += 1;
+        let rank = if reverse { n - 1 - dst } else { dst };
+        sorted[rank as usize] = *px;
+    }
+    run.copy_from_slice(sorted);
+}
+
+fn sort_row(row: &mut [Rgba], cutoff: u8, reverse: bool, sorted: &mut Vec<Rgba>) {
+    let n = row.len();
     let mut i = 0;
     while i < n {
-        if key_of(&pixels[idx[i] * 4..idx[i] * 4 + 4]) <= cutoff {
+        if key_of(&row[i]) <= cutoff {
             i += 1;
             continue;
         }
         let start = i;
-        while i < n && key_of(&pixels[idx[i] * 4..idx[i] * 4 + 4]) > cutoff {
+        while i < n && key_of(&row[i]) > cutoff {
             i += 1;
         }
-        let run = &idx[start..i];
-        let mut count = [0u32; 256];
-        let keys: Vec<u8> = run
-            .iter()
-            .map(|&p| key_of(&pixels[p * 4..p * 4 + 4]))
-            .collect();
-        for &k in &keys {
-            count[k as usize] += 1;
-        }
-        let mut offset = [0u32; 256];
-        let mut acc = 0u32;
-        for b in 0..256 {
-            offset[b] = acc;
-            acc += count[b];
-        }
-        let snapshot: Vec<[u8; 4]> = run
-            .iter()
-            .map(|&p| {
-                let s = &pixels[p * 4..p * 4 + 4];
-                [s[0], s[1], s[2], s[3]]
-            })
-            .collect();
-        let run_len = run.len() as u32;
-        for (j, &k) in keys.iter().enumerate() {
-            let dst_rank = offset[k as usize];
-            offset[k as usize] += 1;
-            let rank = if reverse {
-                run_len - 1 - dst_rank
-            } else {
-                dst_rank
-            };
-            let slot = run[rank as usize];
-            pixels[slot * 4..slot * 4 + 4].copy_from_slice(&snapshot[j]);
-        }
+        counting_sort_run(&mut row[start..i], reverse, sorted);
     }
+}
+
+fn transpose(src: &[Rgba], width: usize, height: usize) -> Vec<Rgba> {
+    let mut out = vec![Rgba::default(); src.len()];
+    out.par_chunks_mut(height)
+        .enumerate()
+        .for_each(|(x, col)| {
+            for (y, dst) in col.iter_mut().enumerate() {
+                *dst = src[y * width + x];
+            }
+        });
+    out
 }
 
 pub fn pixel_sort_cpu(
@@ -165,23 +173,38 @@ pub fn pixel_sort_cpu(
     angle: f32,
 ) -> Vec<u8> {
     let mut out = src.to_vec();
+    if width == 0 || height == 0 {
+        return out;
+    }
     let cutoff = key_cutoff(threshold);
     match SortMode::from_angle(angle) {
         SortMode::Cardinal(SortAxis::Horizontal { reverse }) => {
-            for y in 0..height {
-                let idx: Vec<usize> = (0..width).map(|x| y * width + x).collect();
-                sort_line(&mut out, &idx, cutoff, reverse);
-            }
+            let px: &mut [Rgba] = bytemuck::cast_slice_mut(&mut out);
+            px.par_chunks_mut(width).for_each_init(Vec::new, |scratch, row| {
+                sort_row(row, cutoff, reverse, scratch);
+            });
         }
         SortMode::Cardinal(SortAxis::Vertical { reverse }) => {
-            for x in 0..width {
-                let idx: Vec<usize> = (0..height).map(|y| y * width + x).collect();
-                sort_line(&mut out, &idx, cutoff, reverse);
-            }
+            let px: &[Rgba] = bytemuck::cast_slice(&out);
+            let mut t = transpose(px, width, height);
+            t.par_chunks_mut(height).for_each_init(Vec::new, |scratch, col| {
+                sort_row(col, cutoff, reverse, scratch);
+            });
+            let back = transpose(&t, height, width);
+            out.copy_from_slice(bytemuck::cast_slice(&back));
         }
         SortMode::Diagonal { dx, dy } => {
-            for idx in diagonal_lines(width, height, dx, dy) {
-                sort_line(&mut out, &idx, cutoff, false);
+            let lines = diagonal_lines(width, height, dx, dy);
+            let px: &mut [Rgba] = bytemuck::cast_slice_mut(&mut out);
+            let mut gather: Vec<Rgba> = Vec::new();
+            let mut scratch: Vec<Rgba> = Vec::new();
+            for idx in &lines {
+                gather.clear();
+                gather.extend(idx.iter().map(|&i| px[i]));
+                sort_row(&mut gather, cutoff, false, &mut scratch);
+                for (&i, &p) in idx.iter().zip(gather.iter()) {
+                    px[i] = p;
+                }
             }
         }
     }
@@ -226,6 +249,27 @@ mod tests {
         let out = pixel_sort_cpu(&src, 4, 1, 0.0, 180.0);
         let vals: Vec<u8> = (0..4).map(|x| out[x * 4]).collect();
         assert_eq!(vals, vec![200, 150, 100, 50]);
+    }
+
+    #[test]
+    fn horizontal_sorts_each_row_independently() {
+        let g = |v: u8| [v, v, v, 255u8];
+        let mut src = Vec::new();
+        for v in [200u8, 50, 150, 100, 10, 240, 30, 120] {
+            src.extend_from_slice(&g(v));
+        }
+        let out = pixel_sort_cpu(&src, 4, 2, 0.0, 0.0);
+        let row0: Vec<u8> = (0..4).map(|x| out[x * 4]).collect();
+        let row1: Vec<u8> = (4..8).map(|x| out[x * 4]).collect();
+        assert_eq!(row0, vec![50, 100, 150, 200]);
+        assert_eq!(row1, vec![10, 30, 120, 240]);
+    }
+
+    #[test]
+    fn empty_dimensions_return_input_unchanged() {
+        let src = vec![1u8, 2, 3, 4];
+        assert_eq!(pixel_sort_cpu(&src, 0, 0, 0.0, 0.0), src);
+        assert_eq!(pixel_sort_cpu(&[], 0, 5, 0.0, 90.0), Vec::<u8>::new());
     }
 
     #[test]
@@ -327,6 +371,99 @@ mod tests {
                 10,
                 "off-diagonal pixel {off} must be unchanged"
             );
+        }
+    }
+
+    fn reference_sort(src: &[u8], w: usize, h: usize, cutoff: u8, vertical: bool, reverse: bool) -> Vec<u8> {
+        let mut out = src.to_vec();
+        let line = |k: usize| -> Vec<usize> {
+            if vertical {
+                (0..h).map(|y| y * w + k).collect()
+            } else {
+                (0..w).map(|x| k * w + x).collect()
+            }
+        };
+        let count = if vertical { w } else { h };
+        for k in 0..count {
+            let idx = line(k);
+            let n = idx.len();
+            let mut i = 0;
+            while i < n {
+                let key = |p: usize| key_of(&out[idx[p] * 4..idx[p] * 4 + 4]);
+                if key(i) <= cutoff {
+                    i += 1;
+                    continue;
+                }
+                let start = i;
+                while i < n && key(i) > cutoff {
+                    i += 1;
+                }
+                let run: Vec<[u8; 4]> = (start..i)
+                    .map(|p| {
+                        let s = &out[idx[p] * 4..idx[p] * 4 + 4];
+                        [s[0], s[1], s[2], s[3]]
+                    })
+                    .collect();
+                let mut keyed: Vec<(u8, [u8; 4])> =
+                    run.iter().map(|&px| (key_of(&px), px)).collect();
+                keyed.sort_by_key(|&(k, _)| k);
+                for (off, (_, px)) in keyed.into_iter().enumerate() {
+                    let rank = if reverse { (i - start) - 1 - off } else { off };
+                    let slot = idx[start + rank];
+                    out[slot * 4..slot * 4 + 4].copy_from_slice(&px);
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn matches_reference_on_random_images() {
+        let mut state = 0x2545_f491_4f6c_dd1du64;
+        let mut rng = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 33) as u8
+        };
+        for &(w, h) in &[(1usize, 1usize), (7, 5), (5, 7), (16, 16), (31, 17)] {
+            let src: Vec<u8> = (0..w * h * 4).map(|_| rng()).collect();
+            for &thr in &[0.0f32, 0.3, 0.6] {
+                let cutoff = key_cutoff(thr);
+                for &(angle, vertical, reverse) in
+                    &[(0.0f32, false, false), (180.0, false, true), (90.0, true, false), (270.0, true, true)]
+                {
+                    let got = pixel_sort_cpu(&src, w, h, thr, angle);
+                    let want = reference_sort(&src, w, h, cutoff, vertical, reverse);
+                    assert_eq!(
+                        got, want,
+                        "mismatch at {w}x{h} thr={thr} angle={angle}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "timing benchmark; run with --release --ignored"]
+    fn bench_large_image() {
+        use std::time::Instant;
+        let (w, h) = (4000usize, 3000usize);
+        let mut state = 1u64;
+        let mut rng = || {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state >> 33) as u8
+        };
+        let src: Vec<u8> = (0..w * h * 4).map(|_| rng()).collect();
+
+        for &(label, angle) in &[("horizontal", 0.0f32), ("vertical", 90.0), ("diagonal", 45.0)] {
+            let t = Instant::now();
+            let out = pixel_sort_cpu(&src, w, h, 0.3, angle);
+            let ms = t.elapsed().as_secs_f64() * 1000.0;
+            std::hint::black_box(&out);
+            println!("{label:>11}: {ms:.1} ms  ({w}x{h})");
         }
     }
 }

--- a/src/modifiers/pixel_sort.rs
+++ b/src/modifiers/pixel_sort.rs
@@ -1,0 +1,154 @@
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SortAxis {
+    Horizontal { reverse: bool },
+    Vertical { reverse: bool },
+}
+
+impl SortAxis {
+    pub fn from_angle(angle: f32) -> Self {
+        let q = (((angle / 90.0).round() as i32) % 4 + 4) % 4;
+        match q {
+            0 => SortAxis::Horizontal { reverse: false },
+            1 => SortAxis::Vertical { reverse: false },
+            2 => SortAxis::Horizontal { reverse: true },
+            _ => SortAxis::Vertical { reverse: true },
+        }
+    }
+}
+
+pub fn key_of(p: &[u8]) -> u8 {
+    let y = 0.2126 * p[0] as f32 + 0.7152 * p[1] as f32 + 0.0722 * p[2] as f32;
+    (y + 0.5).clamp(0.0, 255.0) as u8
+}
+
+pub fn key_cutoff(threshold: f32) -> u8 {
+    (threshold * 255.0 + 0.5).clamp(0.0, 255.0) as u8
+}
+
+fn sort_line(pixels: &mut [u8], idx: &[usize], cutoff: u8, reverse: bool) {
+    let n = idx.len();
+    let mut i = 0;
+    while i < n {
+        if key_of(&pixels[idx[i] * 4..idx[i] * 4 + 4]) <= cutoff {
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < n && key_of(&pixels[idx[i] * 4..idx[i] * 4 + 4]) > cutoff {
+            i += 1;
+        }
+        let run = &idx[start..i];
+        let mut count = [0u32; 256];
+        let keys: Vec<u8> = run
+            .iter()
+            .map(|&p| key_of(&pixels[p * 4..p * 4 + 4]))
+            .collect();
+        for &k in &keys {
+            count[k as usize] += 1;
+        }
+        let mut offset = [0u32; 256];
+        let mut acc = 0u32;
+        for b in 0..256 {
+            offset[b] = acc;
+            acc += count[b];
+        }
+        let snapshot: Vec<[u8; 4]> = run
+            .iter()
+            .map(|&p| {
+                let s = &pixels[p * 4..p * 4 + 4];
+                [s[0], s[1], s[2], s[3]]
+            })
+            .collect();
+        let run_len = run.len() as u32;
+        for (j, &k) in keys.iter().enumerate() {
+            let dst_rank = offset[k as usize];
+            offset[k as usize] += 1;
+            let rank = if reverse {
+                run_len - 1 - dst_rank
+            } else {
+                dst_rank
+            };
+            let slot = run[rank as usize];
+            pixels[slot * 4..slot * 4 + 4].copy_from_slice(&snapshot[j]);
+        }
+    }
+}
+
+pub fn pixel_sort_cpu(
+    src: &[u8],
+    width: usize,
+    height: usize,
+    threshold: f32,
+    angle: f32,
+) -> Vec<u8> {
+    let mut out = src.to_vec();
+    let cutoff = key_cutoff(threshold);
+    match SortAxis::from_angle(angle) {
+        SortAxis::Horizontal { reverse } => {
+            for y in 0..height {
+                let idx: Vec<usize> = (0..width).map(|x| y * width + x).collect();
+                sort_line(&mut out, &idx, cutoff, reverse);
+            }
+        }
+        SortAxis::Vertical { reverse } => {
+            for x in 0..width {
+                let idx: Vec<usize> = (0..height).map(|y| y * width + x).collect();
+                sort_line(&mut out, &idx, cutoff, reverse);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn horizontal_sorts_above_threshold_run_ascending() {
+        let g = |v: u8| [v, v, v, 255u8];
+        let mut src = Vec::new();
+        for v in [200u8, 50, 150, 100] {
+            src.extend_from_slice(&g(v));
+        }
+        let out = pixel_sort_cpu(&src, 4, 1, 0.0, 0.0);
+        let vals: Vec<u8> = (0..4).map(|x| out[x * 4]).collect();
+        assert_eq!(vals, vec![50, 100, 150, 200]);
+    }
+
+    #[test]
+    fn threshold_pins_dark_pixels_and_segments() {
+        let g = |v: u8| [v, v, v, 255u8];
+        let mut src = Vec::new();
+        for v in [200u8, 10, 200, 100] {
+            src.extend_from_slice(&g(v));
+        }
+        let out = pixel_sort_cpu(&src, 4, 1, 0.1, 0.0);
+        let vals: Vec<u8> = (0..4).map(|x| out[x * 4]).collect();
+        assert_eq!(vals, vec![200, 10, 100, 200]);
+    }
+
+    #[test]
+    fn reverse_sorts_descending() {
+        let g = |v: u8| [v, v, v, 255u8];
+        let mut src = Vec::new();
+        for v in [50u8, 200, 100, 150] {
+            src.extend_from_slice(&g(v));
+        }
+        let out = pixel_sort_cpu(&src, 4, 1, 0.0, 180.0);
+        let vals: Vec<u8> = (0..4).map(|x| out[x * 4]).collect();
+        assert_eq!(vals, vec![200, 150, 100, 50]);
+    }
+
+    #[test]
+    fn vertical_axis_sorts_columns() {
+        let g = |v: u8| [v, v, v, 255u8];
+        let mut src = Vec::new();
+        for v in [150u8, 50, 100] {
+            src.extend_from_slice(&g(v));
+        }
+        let out = pixel_sort_cpu(&src, 1, 3, 0.0, 90.0);
+        let vals: Vec<u8> = (0..3).map(|y| out[y * 4]).collect();
+        assert_eq!(vals, vec![50, 100, 150]);
+    }
+}

--- a/src/modifiers/text_render.rs
+++ b/src/modifiers/text_render.rs
@@ -595,12 +595,18 @@ mod sdf_tests {
         if first.is_empty() {
             return;
         }
-        let before = lock_sdf_cache().len();
-        let _second = shape_glyphs(&text);
-        let after = lock_sdf_cache().len();
+        let second = shape_glyphs(&text);
         assert_eq!(
-            before, after,
-            "re-shaping identical text adds no new glyphs"
+            first.glyphs.len(),
+            second.glyphs.len(),
+            "re-shaping identical text yields the same glyphs"
         );
+        let cache = lock_sdf_cache();
+        for g in &second.glyphs {
+            assert!(
+                cache.contains_key(&g.key),
+                "shaped glyph should be present in the SDF cache"
+            );
+        }
     }
 }

--- a/src/modifiers/types.rs
+++ b/src/modifiers/types.rs
@@ -35,13 +35,6 @@ impl InputRequest {
             _ => None,
         }
     }
-
-    pub fn scan_axis(&self) -> Option<Axis> {
-        match self {
-            InputRequest::ScanLines { axis } => Some(*axis),
-            _ => None,
-        }
-    }
 }
 
 pub trait ModifierImpl {

--- a/src/modifiers/types.rs
+++ b/src/modifiers/types.rs
@@ -28,12 +28,45 @@ impl InputRequest {
     pub fn is_pointwise(&self) -> bool {
         matches!(self, InputRequest::SamplePoint)
     }
+}
 
-    pub fn neighborhood_radius(&self) -> Option<f32> {
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EffectClass {
+    Pointwise,
+    Fragment,
+    Separable { apron_px: f32 },
+    ComputeScanline { axis: Axis },
+}
+
+impl EffectClass {
+    pub fn from_input_request(req: InputRequest) -> Self {
+        match req {
+            InputRequest::SamplePoint => EffectClass::Pointwise,
+            InputRequest::FullFrame => EffectClass::Fragment,
+            InputRequest::Neighborhood { radius_px } => EffectClass::Separable {
+                apron_px: radius_px,
+            },
+            InputRequest::ScanLines { axis } => EffectClass::ComputeScanline { axis },
+        }
+    }
+
+    pub fn is_pointwise(&self) -> bool {
+        matches!(self, EffectClass::Pointwise)
+    }
+
+    pub fn is_fragment(&self) -> bool {
+        matches!(self, EffectClass::Fragment)
+    }
+
+    pub fn separable_apron(&self) -> Option<f32> {
         match self {
-            InputRequest::Neighborhood { radius_px } => Some(*radius_px),
+            EffectClass::Separable { apron_px } => Some(*apron_px),
             _ => None,
         }
+    }
+
+    pub fn is_compute_scanline(&self) -> bool {
+        matches!(self, EffectClass::ComputeScanline { .. })
     }
 }
 
@@ -46,6 +79,10 @@ pub trait ModifierImpl {
 
     fn input_request(&self) -> InputRequest {
         InputRequest::SamplePoint
+    }
+
+    fn effect_class(&self) -> EffectClass {
+        EffectClass::from_input_request(self.input_request())
     }
 
     fn apply_param(&mut self, param: ModifierParam, img_size: Option<(u32, u32)>);
@@ -164,6 +201,10 @@ impl ModifierKind {
         self.as_impl().input_request()
     }
 
+    pub fn effect_class(&self) -> EffectClass {
+        self.as_impl().effect_class()
+    }
+
     pub fn apply_param(&mut self, param: ModifierParam, img_size: Option<(u32, u32)>) {
         self.as_impl_mut().apply_param(param, img_size);
     }
@@ -254,6 +295,43 @@ pub enum ModifierParam {
     DrawingOpacity(f32),
     DrawingSize(f32),
     DrawingHardness(f32),
+}
+
+#[cfg(test)]
+mod effect_class_tests {
+    use super::*;
+    use crate::modifiers::kinds::{ChromaticAberration, Exposure, GaussianBlur, PixelSort, Text};
+
+    fn class(k: ModifierKind) -> EffectClass {
+        k.effect_class()
+    }
+
+    #[test]
+    fn class_matches_input_request_partition() {
+        assert!(class(ModifierKind::Exposure(Exposure::default())).is_pointwise());
+        assert!(
+            class(ModifierKind::ChromaticAberration(
+                ChromaticAberration::default()
+            ))
+            .is_fragment()
+        );
+        assert!(class(ModifierKind::Text(Text::default())).is_fragment());
+
+        let blur = ModifierKind::GaussianBlur(GaussianBlur { radius: 7.0 });
+        assert_eq!(blur.effect_class().separable_apron(), Some(7.0));
+
+        let sort = ModifierKind::PixelSort(PixelSort {
+            threshold: 0.5,
+            angle: 90.0,
+        });
+        assert!(sort.effect_class().is_compute_scanline());
+        assert!(matches!(
+            sort.effect_class(),
+            EffectClass::ComputeScanline {
+                axis: Axis::Vertical
+            }
+        ));
+    }
 }
 
 pub mod ids {

--- a/src/modifiers/types.rs
+++ b/src/modifiers/types.rs
@@ -11,9 +11,37 @@ use crate::modifiers::kinds::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InputClass {
-    Pointwise,
-    NonPointwise,
+pub enum Axis {
+    Horizontal,
+    Vertical,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum InputRequest {
+    SamplePoint,
+    Neighborhood { radius_px: f32 },
+    ScanLines { axis: Axis },
+    FullFrame,
+}
+
+impl InputRequest {
+    pub fn is_pointwise(&self) -> bool {
+        matches!(self, InputRequest::SamplePoint)
+    }
+
+    pub fn neighborhood_radius(&self) -> Option<f32> {
+        match self {
+            InputRequest::Neighborhood { radius_px } => Some(*radius_px),
+            _ => None,
+        }
+    }
+
+    pub fn scan_axis(&self) -> Option<Axis> {
+        match self {
+            InputRequest::ScanLines { axis } => Some(*axis),
+            _ => None,
+        }
+    }
 }
 
 pub trait ModifierImpl {
@@ -23,8 +51,8 @@ pub trait ModifierImpl {
         true
     }
 
-    fn input_class(&self) -> InputClass {
-        InputClass::Pointwise
+    fn input_request(&self) -> InputRequest {
+        InputRequest::SamplePoint
     }
 
     fn apply_param(&mut self, param: ModifierParam, img_size: Option<(u32, u32)>);
@@ -139,8 +167,8 @@ impl ModifierKind {
         self.as_impl().has_effect()
     }
 
-    pub fn input_class(&self) -> InputClass {
-        self.as_impl().input_class()
+    pub fn input_request(&self) -> InputRequest {
+        self.as_impl().input_request()
     }
 
     pub fn apply_param(&mut self, param: ModifierParam, img_size: Option<(u32, u32)>) {

--- a/src/wgpu/gpu.rs
+++ b/src/wgpu/gpu.rs
@@ -4,13 +4,14 @@ use bytemuck::{Pod, bytes_of};
 use iced::wgpu::{
     BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor,
     BindGroupLayoutEntry, BindingResource, BindingType, BlendState, Buffer, BufferBindingType,
-    BufferDescriptor, BufferUsages, ColorTargetState, ColorWrites, CommandEncoder, Device,
-    Extent3d, FragmentState, LoadOp, MultisampleState, Operations, PipelineCompilationOptions,
-    PipelineLayoutDescriptor, PrimitiveState, PrimitiveTopology, Queue, RenderPassColorAttachment,
-    RenderPassDescriptor, RenderPipeline, RenderPipelineDescriptor, Sampler, SamplerBindingType,
-    ShaderModuleDescriptor, ShaderSource, ShaderStages, StoreOp, Texture, TextureDescriptor,
-    TextureDimension, TextureFormat, TextureSampleType, TextureUsages, TextureView,
-    TextureViewDescriptor, TextureViewDimension, VertexState,
+    BufferDescriptor, BufferUsages, ColorTargetState, ColorWrites, CommandEncoder, ComputePipeline,
+    ComputePipelineDescriptor, Device, Extent3d, FragmentState, LoadOp, MultisampleState,
+    Operations, PipelineCompilationOptions, PipelineLayoutDescriptor, PrimitiveState,
+    PrimitiveTopology, Queue, RenderPassColorAttachment, RenderPassDescriptor, RenderPipeline,
+    RenderPipelineDescriptor, Sampler, SamplerBindingType, ShaderModuleDescriptor, ShaderSource,
+    ShaderStages, StoreOp, Texture, TextureDescriptor, TextureDimension, TextureFormat,
+    TextureSampleType, TextureUsages, TextureView, TextureViewDescriptor, TextureViewDimension,
+    VertexState,
 };
 
 pub fn fullscreen_pipeline(
@@ -301,6 +302,68 @@ pub fn hw_mip_count(w: u32, h: u32) -> u32 {
         return 1;
     }
     32 - max_dim.leading_zeros()
+}
+
+pub fn compute_pipeline(
+    device: &Device,
+    shader_src: &str,
+    entry_point: &str,
+    label: Option<&str>,
+    bind_group_layout: &BindGroupLayout,
+) -> ComputePipeline {
+    let shader = device.create_shader_module(ShaderModuleDescriptor {
+        label,
+        source: ShaderSource::Wgsl(Cow::Borrowed(shader_src)),
+    });
+    let layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+        label,
+        bind_group_layouts: &[bind_group_layout],
+        push_constant_ranges: &[],
+    });
+    device.create_compute_pipeline(&ComputePipelineDescriptor {
+        label,
+        layout: Some(&layout),
+        module: &shader,
+        entry_point: Some(entry_point),
+        compilation_options: PipelineCompilationOptions::default(),
+        cache: None,
+    })
+}
+
+pub fn storage_buffer(device: &Device, bytes: u64, label: Option<&str>) -> Buffer {
+    device.create_buffer(&BufferDescriptor {
+        label,
+        size: bytes.max(4),
+        usage: BufferUsages::STORAGE | BufferUsages::COPY_SRC | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    })
+}
+
+#[allow(dead_code)]
+pub fn readback_buffer(device: &Device, bytes: u64, label: Option<&str>) -> Buffer {
+    device.create_buffer(&BufferDescriptor {
+        label,
+        size: bytes.max(4),
+        usage: BufferUsages::MAP_READ | BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    })
+}
+
+#[allow(dead_code)]
+pub fn read_buffer_blocking(device: &Device, buffer: &Buffer) -> Vec<u8> {
+    let slice = buffer.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(iced::wgpu::MapMode::Read, move |r| {
+        let _ = tx.send(r);
+    });
+    let _ = device.poll(iced::wgpu::PollType::Wait {
+        submission_index: None,
+        timeout: None,
+    });
+    rx.recv().ok();
+    let data = slice.get_mapped_range().to_vec();
+    buffer.unmap();
+    data
 }
 
 pub fn texture_2d_mipmapped(

--- a/src/wgpu/media/image_data.rs
+++ b/src/wgpu/media/image_data.rs
@@ -268,8 +268,9 @@ impl ImageData {
             .dimensions()
             .ok_or_else(|| ImageError::IoError(Error::other("psd: missing dimensions")))?;
         let channels = match decoder.colorspace() {
-            Some(ColorSpace::RGBA) | Some(ColorSpace::LumaA) => 4,
+            Some(ColorSpace::RGBA) => 4,
             Some(ColorSpace::RGB) => 3,
+            Some(ColorSpace::LumaA) => 2,
             Some(ColorSpace::Luma) => 1,
             other => {
                 return Err(ImageError::IoError(Error::other(format!(
@@ -299,6 +300,7 @@ impl ImageData {
             let s = i * channels;
             let (r, g, b, a) = match channels {
                 1 => (samples[s], samples[s], samples[s], 255),
+                2 => (samples[s], samples[s], samples[s], samples[s + 1]),
                 3 => (samples[s], samples[s + 1], samples[s + 2], 255),
                 _ => (samples[s], samples[s + 1], samples[s + 2], samples[s + 3]),
             };
@@ -868,6 +870,66 @@ impl ImageData {
             MediaData::Image(img)
         } else {
             media
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_psd(width: u16, height: u16, color_mode: u16, planes: &[&[u8]]) -> Vec<u8> {
+        let mut b = Vec::new();
+        b.extend_from_slice(b"8BPS");
+        b.extend_from_slice(&1u16.to_be_bytes());
+        b.extend_from_slice(&[0u8; 6]);
+        b.extend_from_slice(&(planes.len() as u16).to_be_bytes());
+        b.extend_from_slice(&(height as u32).to_be_bytes());
+        b.extend_from_slice(&(width as u32).to_be_bytes());
+        b.extend_from_slice(&8u16.to_be_bytes());
+        b.extend_from_slice(&color_mode.to_be_bytes());
+        b.extend_from_slice(&0u32.to_be_bytes());
+        b.extend_from_slice(&0u32.to_be_bytes());
+        b.extend_from_slice(&0u32.to_be_bytes());
+        b.extend_from_slice(&0u16.to_be_bytes());
+        for plane in planes {
+            b.extend_from_slice(plane);
+        }
+        b
+    }
+
+    fn load_bytes(name: &str, bytes: &[u8]) -> Result<ImageData, ImageError> {
+        let path = std::env::temp_dir().join(name);
+        std::fs::write(&path, bytes).unwrap();
+        let result = ImageData::load_psd(&path);
+        let _ = std::fs::remove_file(&path);
+        result
+    }
+
+    #[test]
+    fn psd_grayscale_with_alpha_channel_loads() {
+        let gray = [10u8, 20, 30, 40];
+        let alpha = [255u8, 128, 0, 64];
+        let bytes = raw_psd(2, 2, 1, &[&gray, &alpha]);
+        let img = load_bytes("bloom-test-luma-a.psd", &bytes).expect("grayscale+alpha psd loads");
+        assert_eq!((img.width, img.height), (2, 2));
+        let px = img.pixels_snapshot();
+        for i in 0..4 {
+            let o = i * 4;
+            assert_eq!(&px[o..o + 3], &[gray[i], gray[i], gray[i]], "pixel {i}");
+            assert_eq!(px[o + 3], 255, "alpha {i} (zune-psd drops grayscale alpha)");
+        }
+    }
+
+    #[test]
+    fn psd_grayscale_loads_as_luma() {
+        let gray = [0u8, 85, 170, 255];
+        let bytes = raw_psd(4, 1, 1, &[&gray]);
+        let img = load_bytes("bloom-test-luma.psd", &bytes).expect("grayscale psd loads");
+        let px = img.pixels_snapshot();
+        for i in 0..4 {
+            let o = i * 4;
+            assert_eq!(&px[o..o + 4], &[gray[i], gray[i], gray[i], 255], "pixel {i}");
         }
     }
 }

--- a/src/wgpu/media/image_data.rs
+++ b/src/wgpu/media/image_data.rs
@@ -929,7 +929,11 @@ mod tests {
         let px = img.pixels_snapshot();
         for i in 0..4 {
             let o = i * 4;
-            assert_eq!(&px[o..o + 4], &[gray[i], gray[i], gray[i], 255], "pixel {i}");
+            assert_eq!(
+                &px[o..o + 4],
+                &[gray[i], gray[i], gray[i], 255],
+                "pixel {i}"
+            );
         }
     }
 }

--- a/src/wgpu/media/image_data.rs
+++ b/src/wgpu/media/image_data.rs
@@ -23,13 +23,16 @@ use image::{
 use jpeg2k::Image as Jp2Image;
 use jxl_oxide::JxlImage;
 use ktx2::{Reader as Ktx2Reader, SupercompressionScheme};
-use psd::Psd;
 use resvg;
 use rgb::ComponentBytes;
 use tiny_skia::Pixmap;
 use usvg::Options as SvgOptions;
 use xcf_rs::data::xcf::Xcf;
 use zip::ZipArchive;
+use zune_core::bytestream::ZCursor;
+use zune_core::colorspace::ColorSpace;
+use zune_core::result::DecodingResult;
+use zune_psd::PSDDecoder;
 
 use super::animation::{Animation, Frame};
 use super::exif_data::ExifData;
@@ -257,8 +260,56 @@ impl ImageData {
 
     pub fn load_psd(path: &Path) -> Result<Self, ImageError> {
         let bytes = std::fs::read(path).map_err(ImageError::IoError)?;
-        let psd = Psd::from_bytes(&bytes).map_err(|e| ImageError::IoError(Error::other(e)))?;
-        Ok(Self::new(psd.rgba(), psd.width(), psd.height()))
+        let mut decoder = PSDDecoder::new(ZCursor::new(&bytes));
+        let pixels = decoder
+            .decode()
+            .map_err(|e| ImageError::IoError(Error::other(format!("{e:?}"))))?;
+        let (width, height) = decoder
+            .dimensions()
+            .ok_or_else(|| ImageError::IoError(Error::other("psd: missing dimensions")))?;
+        let channels = match decoder.colorspace() {
+            Some(ColorSpace::RGBA) | Some(ColorSpace::LumaA) => 4,
+            Some(ColorSpace::RGB) => 3,
+            Some(ColorSpace::Luma) => 1,
+            other => {
+                return Err(ImageError::IoError(Error::other(format!(
+                    "psd: unsupported color mode {other:?}"
+                ))));
+            }
+        };
+
+        let samples: Vec<u8> = match pixels {
+            DecodingResult::U8(v) => v,
+            DecodingResult::U16(v) => v.into_iter().map(|s| (s >> 8) as u8).collect(),
+            _ => {
+                return Err(ImageError::IoError(Error::other(
+                    "psd: unsupported sample type",
+                )));
+            }
+        };
+
+        let px_count = width * height;
+        if samples.len() < px_count * channels {
+            return Err(ImageError::IoError(Error::other(
+                "psd: pixel data shorter than image dimensions",
+            )));
+        }
+        let mut rgba = vec![0u8; px_count * 4];
+        for i in 0..px_count {
+            let s = i * channels;
+            let (r, g, b, a) = match channels {
+                1 => (samples[s], samples[s], samples[s], 255),
+                3 => (samples[s], samples[s + 1], samples[s + 2], 255),
+                _ => (samples[s], samples[s + 1], samples[s + 2], samples[s + 3]),
+            };
+            let d = i * 4;
+            rgba[d] = r;
+            rgba[d + 1] = g;
+            rgba[d + 2] = b;
+            rgba[d + 3] = a;
+        }
+
+        Ok(Self::new(rgba, width as u32, height as u32))
     }
 
     pub fn load_kra(path: &Path) -> Result<Self, ImageError> {

--- a/src/wgpu/modifier_pipeline.rs
+++ b/src/wgpu/modifier_pipeline.rs
@@ -174,6 +174,13 @@ fn process_vram_budget(device: &Device) -> u64 {
         .clamp(PROCESS_VRAM_BUDGET_MIN, PROCESS_VRAM_BUDGET_MAX)
 }
 
+fn sort_buffer_limit(device: &Device) -> u64 {
+    let limits = device.limits();
+    limits
+        .max_buffer_size
+        .min(limits.max_storage_buffer_binding_size as u64)
+}
+
 fn fit_process_scale(
     unit_w: u32,
     unit_h: u32,
@@ -1509,7 +1516,7 @@ impl ModifierPipeline {
             proc_scale,
         );
         if has_diag {
-            let max_bytes = device.limits().max_buffer_size;
+            let max_bytes = sort_buffer_limit(device);
             while scale > 1.0 / 4096.0 {
                 let sw = scaled(source.full_width, scale).max(1) as u64;
                 let sh = scaled(source.full_height, scale).max(1) as u64;
@@ -1988,7 +1995,7 @@ impl ModifierPipeline {
         budgeted: bool,
         scale: f32,
     ) -> bool {
-        let budget = device.limits().max_buffer_size.min(PIXEL_SORT_BUF_BUDGET);
+        let budget = sort_buffer_limit(device).min(PIXEL_SORT_BUF_BUDGET);
         let line_len = if vertical {
             scaled(source.full_height, scale)
         } else {
@@ -2171,7 +2178,7 @@ impl ModifierPipeline {
         let row_bytes = (full_sw * 4).div_ceil(256) * 256;
         let row_words = row_bytes / 4;
         let bytes = row_bytes as u64 * full_sh as u64;
-        if bytes > device.limits().max_buffer_size {
+        if bytes > sort_buffer_limit(device) {
             return;
         }
         self.ensure_sort_buffers(device, bytes);
@@ -2307,7 +2314,7 @@ impl ModifierPipeline {
         let row_bytes = (w * 4).div_ceil(256) * 256;
         let row_words = row_bytes / 4;
         let bytes = row_bytes as u64 * h as u64;
-        if bytes > device.limits().max_buffer_size {
+        if bytes > sort_buffer_limit(device) {
             return;
         }
         self.ensure_sort_buffers(device, bytes);
@@ -2366,7 +2373,7 @@ impl ModifierPipeline {
         angle: f32,
         vertical: bool,
     ) {
-        let budget = device.limits().max_buffer_size.min(PIXEL_SORT_BUF_BUDGET);
+        let budget = sort_buffer_limit(device).min(PIXEL_SORT_BUF_BUDGET);
         let cross = if vertical { w } else { h };
         let line_px = if vertical { h as u64 } else { w as u64 };
         let band = (budget / (line_px * 4).max(1))

--- a/src/wgpu/modifier_pipeline.rs
+++ b/src/wgpu/modifier_pipeline.rs
@@ -7,13 +7,15 @@ use iced::wgpu::{
 
 use crate::{
     modifiers::{
-        InputClass, Modifier, ModifierKind,
+        Modifier, ModifierKind,
         gpu::{ModUniforms, TileInfo, build_segment_uniforms},
     },
     wgpu::{
         gpu,
         passes::{
             chromatic_aberration::ChromaticAberrationPass,
+            gaussian_blur::{GaussianBlurPass, TileRect},
+            pixel_sort::PixelSortCompute,
             text::{TextLayer, TextPass},
         },
         tiled_source::TiledSource,
@@ -73,6 +75,9 @@ struct TileOutput {
     valid: bool,
     width: u32,
     height: u32,
+    proc_px: Option<[f32; 4]>,
+    proc_scale: f32,
+    band_y: u32,
 }
 
 struct ScratchTarget {
@@ -89,7 +94,10 @@ impl ScratchTarget {
             width,
             height,
             format,
-            TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+            TextureUsages::RENDER_ATTACHMENT
+                | TextureUsages::TEXTURE_BINDING
+                | TextureUsages::COPY_SRC
+                | TextureUsages::COPY_DST,
             Some("modifier-scratch"),
         );
         let view = tex.create_view(&Default::default());
@@ -107,6 +115,295 @@ enum PlanItem<'a> {
     Step(usize, &'a Modifier),
 }
 
+#[derive(Clone, Copy)]
+enum SortTarget {
+    ScratchA,
+    ScratchB,
+    Output,
+}
+
+const TILE_BUDGET: usize = 2;
+
+struct Scheduler {
+    budget: usize,
+    deferred: bool,
+}
+
+impl Scheduler {
+    fn new() -> Self {
+        Self {
+            budget: TILE_BUDGET,
+            deferred: false,
+        }
+    }
+
+    fn admit(&mut self) -> bool {
+        if self.budget == 0 {
+            self.deferred = true;
+            false
+        } else {
+            self.budget -= 1;
+            true
+        }
+    }
+
+    fn pending(&self) -> bool {
+        self.deferred
+    }
+}
+
+#[derive(Default)]
+struct StepPools {
+    fused: usize,
+    ca: usize,
+    text: usize,
+}
+
+const ROI_MARGIN_PX: f32 = 256.0;
+
+const PIXEL_SORT_BUF_BUDGET: u64 = 64 * 1024 * 1024;
+const PIXEL_SORT_LINES_PER_BAND: u32 = 64;
+const PIXEL_SORT_BANDS_PER_FRAME: u32 = 4;
+const PROCESS_VRAM_BUDGET_MIN: u64 = 512 * 1024 * 1024;
+const PROCESS_VRAM_BUDGET_MAX: u64 = 4 * 1024 * 1024 * 1024;
+
+fn process_vram_budget(device: &Device) -> u64 {
+    device
+        .limits()
+        .max_buffer_size
+        .clamp(PROCESS_VRAM_BUDGET_MIN, PROCESS_VRAM_BUDGET_MAX)
+}
+
+fn fit_process_scale(
+    unit_w: u32,
+    unit_h: u32,
+    n_units: u64,
+    banks: u64,
+    budget: u64,
+    base: f32,
+) -> f32 {
+    let mut scale = base.clamp(1.0 / 4096.0, 1.0).log2().floor().exp2();
+    loop {
+        let w = ((unit_w as f32 * scale).round() as u64).max(1);
+        let h = ((unit_h as f32 * scale).round() as u64).max(1);
+        let total = w * h * 4 * banks * n_units.max(1);
+        if total <= budget || scale <= 1.0 / 4096.0 {
+            break;
+        }
+        scale *= 0.5;
+    }
+    scale
+}
+
+fn scaled(coord: u32, scale: f32) -> u32 {
+    (coord as f32 * scale).round() as u32
+}
+
+const BLUR_WORK_BUDGET: u32 = 24_000_000;
+const BLUR_MIN_BAND_H: u32 = 8;
+const BLUR_MAX_BAND_H: u32 = 1024;
+
+#[derive(Default, Clone, Copy)]
+struct Neighbors {
+    left: Option<usize>,
+    right: Option<usize>,
+    up: Option<usize>,
+    down: Option<usize>,
+}
+
+use crate::modifiers::gpu::UvRect;
+use crate::modifiers::pixel_sort::SortAxis;
+
+struct ProcRect {
+    px: [f32; 4],
+    proc: UvRect,
+    src: UvRect,
+    w: u32,
+    h: u32,
+}
+
+fn tile_proc_rect(
+    tile: &crate::wgpu::tiled_source::Tile,
+    full_w: f32,
+    full_h: f32,
+    proc_scale: f32,
+    downscale: bool,
+    apron_px: f32,
+    roi_enabled: bool,
+) -> ProcRect {
+    let fw = tile.x as f32 + tile.width as f32;
+    let fh = tile.y as f32 + tile.height as f32;
+    let tl = tile.x as f32;
+    let tt = tile.y as f32;
+
+    let margin_px = if downscale { 0.0 } else { ROI_MARGIN_PX };
+    let roi = if roi_enabled { tile.proc_rect_px } else { None };
+    let px = match roi {
+        Some([l, t, r, b]) => {
+            let grow = apron_px + margin_px;
+            [
+                (l - grow).floor().max(tl),
+                (t - grow).floor().max(tt),
+                (r + grow).ceil().min(fw),
+                (b + grow).ceil().min(fh),
+            ]
+        }
+        None => [tl, tt, fw, fh],
+    };
+
+    let pw_px = (px[2] - px[0]).max(1.0);
+    let ph_px = (px[3] - px[1]).max(1.0);
+    let scale = if downscale { proc_scale } else { 1.0 };
+    let w = ((pw_px * scale).ceil() as u32).max(1);
+    let h = ((ph_px * scale).ceil() as u32).max(1);
+
+    let proc = UvRect {
+        origin: [px[0] / full_w, px[1] / full_h],
+        size: [(px[2] - px[0]) / full_w, (px[3] - px[1]) / full_h],
+    };
+    let src = UvRect {
+        origin: [tl / full_w, tt / full_h],
+        size: [tile.width as f32 / full_w, tile.height as f32 / full_h],
+    };
+    ProcRect {
+        px,
+        proc,
+        src,
+        w,
+        h,
+    }
+}
+
+fn inscribe_transform(base: glam::Mat4, isec: [f32; 4], sub: [f32; 4]) -> glam::Mat4 {
+    let [il, it, ir, ib] = isec;
+    let iw = (ir - il).max(1e-6);
+    let ih = (ib - it).max(1e-6);
+    let qx = |x: f32| -1.0 + 2.0 * (x - il) / iw;
+    let qy = |y: f32| 1.0 - 2.0 * (y - it) / ih;
+    let qx0 = qx(sub[0]);
+    let qx1 = qx(sub[2]);
+    let qy_top = qy(sub[1]);
+    let qy_bot = qy(sub[3]);
+    let cx = (qx0 + qx1) * 0.5;
+    let cy = (qy_top + qy_bot) * 0.5;
+    let hx = (qx1 - qx0) * 0.5;
+    let hy = (qy_top - qy_bot) * 0.5;
+    base * glam::Mat4::from_translation(glam::vec3(cx, cy, 0.0))
+        * glam::Mat4::from_scale(glam::vec3(hx, hy, 1.0))
+}
+
+fn rect_contains(outer: [f32; 4], inner: [f32; 4]) -> bool {
+    inner[0] >= outer[0] - 0.5
+        && inner[1] >= outer[1] - 0.5
+        && inner[2] <= outer[2] + 0.5
+        && inner[3] <= outer[3] + 0.5
+}
+
+fn proc_rect_from_px(
+    proc_px: Option<[f32; 4]>,
+    tile: &crate::wgpu::tiled_source::Tile,
+    full_w: f32,
+    full_h: f32,
+    w: u32,
+    h: u32,
+) -> ProcRect {
+    let px = proc_px.unwrap_or([
+        tile.x as f32,
+        tile.y as f32,
+        tile.x as f32 + tile.width as f32,
+        tile.y as f32 + tile.height as f32,
+    ]);
+    let proc = UvRect {
+        origin: [px[0] / full_w, px[1] / full_h],
+        size: [(px[2] - px[0]) / full_w, (px[3] - px[1]) / full_h],
+    };
+    let src = UvRect {
+        origin: [tile.x as f32 / full_w, tile.y as f32 / full_h],
+        size: [tile.width as f32 / full_w, tile.height as f32 / full_h],
+    };
+    ProcRect {
+        px,
+        proc,
+        src,
+        w,
+        h,
+    }
+}
+
+fn full_rect(tile: &TileInfo) -> TileRect {
+    TileRect {
+        origin: [
+            tile.tile_x as f32 / tile.full_w as f32,
+            tile.tile_y as f32 / tile.full_h as f32,
+        ],
+        size: [
+            tile.tile_w as f32 / tile.full_w as f32,
+            tile.tile_h as f32 / tile.full_h as f32,
+        ],
+    }
+}
+
+fn tile_neighbors(tiles: &[crate::wgpu::tiled_source::Tile], ti: usize) -> Neighbors {
+    let t = &tiles[ti];
+    let mut n = Neighbors::default();
+    for (j, o) in tiles.iter().enumerate() {
+        if j == ti {
+            continue;
+        }
+        if o.y == t.y && o.x + o.width == t.x {
+            n.left = Some(j);
+        } else if o.y == t.y && t.x + t.width == o.x {
+            n.right = Some(j);
+        } else if o.x == t.x && o.y + o.height == t.y {
+            n.up = Some(j);
+        } else if o.x == t.x && t.y + t.height == o.y {
+            n.down = Some(j);
+        }
+    }
+    n
+}
+
+fn tex_copy_info(
+    tex: &Texture,
+    origin: iced::wgpu::Origin3d,
+) -> iced::wgpu::TexelCopyTextureInfo<'_> {
+    iced::wgpu::TexelCopyTextureInfo {
+        texture: tex,
+        mip_level: 0,
+        origin,
+        aspect: iced::wgpu::TextureAspect::All,
+    }
+}
+
+fn pixel_sort_groups(source: &TiledSource, proc_set: &[usize], vertical: bool) -> Vec<Vec<usize>> {
+    let mut groups: Vec<Vec<usize>> = Vec::new();
+    let mut keys: Vec<u32> = Vec::new();
+    for &ti in proc_set {
+        let key = if vertical {
+            source.tiles[ti].x
+        } else {
+            source.tiles[ti].y
+        };
+        let gi = match keys.iter().position(|&k| k == key) {
+            Some(i) => i,
+            None => {
+                keys.push(key);
+                groups.push(Vec::new());
+                groups.len() - 1
+            }
+        };
+        groups[gi].push(ti);
+    }
+    for g in &mut groups {
+        if vertical {
+            g.sort_by_key(|&ti| source.tiles[ti].y);
+        } else {
+            g.sort_by_key(|&ti| source.tiles[ti].x);
+        }
+    }
+    groups
+}
+
 fn plan_modifiers(modifiers: &[Modifier]) -> Vec<PlanItem<'_>> {
     let mut plan: Vec<PlanItem> = Vec::new();
     let mut current: Vec<&Modifier> = Vec::new();
@@ -114,7 +411,7 @@ fn plan_modifiers(modifiers: &[Modifier]) -> Vec<PlanItem<'_>> {
         if !m.has_visible_effect() {
             continue;
         }
-        if matches!(m.kind.input_class(), InputClass::NonPointwise) {
+        if !m.kind.input_request().is_pointwise() {
             if !current.is_empty() {
                 plan.push(PlanItem::Fused(std::mem::take(&mut current)));
             }
@@ -137,13 +434,29 @@ pub struct ModifierPipeline {
     scratch_a: Option<ScratchTarget>,
     scratch_b: Option<ScratchTarget>,
 
+    scratch_blur: Option<ScratchTarget>,
+    bank_a: Vec<Option<ScratchTarget>>,
+    bank_b: Vec<Option<ScratchTarget>>,
+    blur_hmid: Vec<Option<ScratchTarget>>,
+    blur_vstrip_top: Vec<Option<ScratchTarget>>,
+    blur_vstrip_bot: Vec<Option<ScratchTarget>>,
+    roi_display_uniforms: Vec<Option<iced::wgpu::Buffer>>,
+    reprocess_pending: bool,
+
     uniform_pool: Vec<iced::wgpu::Buffer>,
     ca_uniform_pool: Vec<iced::wgpu::Buffer>,
+    blur_uniform_pool: Vec<iced::wgpu::Buffer>,
     text_uniform_pool: Vec<iced::wgpu::Buffer>,
+    pixel_sort_uniform_pool: Vec<iced::wgpu::Buffer>,
+    sort_buffers: Option<(iced::wgpu::Buffer, iced::wgpu::Buffer)>,
+    sort_band_cursor: u32,
+    sort_progress_sig: u64,
     text_layers: Vec<Option<TextLayer>>,
     text_sigs: Vec<Option<u64>>,
     combined: CombinedPass,
     chromatic_aberration: ChromaticAberrationPass,
+    gaussian_blur: GaussianBlurPass,
+    pixel_sort: PixelSortCompute,
     text: TextPass,
     display_bgl: BindGroupLayout,
     trilinear_sampler: Sampler,
@@ -197,13 +510,28 @@ impl ModifierPipeline {
             tile_display_bgs_nearest: Vec::new(),
             scratch_a: None,
             scratch_b: None,
+            scratch_blur: None,
+            bank_a: Vec::new(),
+            bank_b: Vec::new(),
+            blur_hmid: Vec::new(),
+            blur_vstrip_top: Vec::new(),
+            blur_vstrip_bot: Vec::new(),
+            roi_display_uniforms: Vec::new(),
+            reprocess_pending: false,
             uniform_pool: Vec::new(),
             ca_uniform_pool: Vec::new(),
+            blur_uniform_pool: Vec::new(),
             text_uniform_pool: Vec::new(),
+            pixel_sort_uniform_pool: Vec::new(),
+            sort_buffers: None,
+            sort_band_cursor: 0,
+            sort_progress_sig: 0,
             text_layers: Vec::new(),
             text_sigs: Vec::new(),
             combined: CombinedPass::new(device, format),
             chromatic_aberration: ChromaticAberrationPass::new(device, format),
+            gaussian_blur: GaussianBlurPass::new(device, format),
+            pixel_sort: PixelSortCompute::new(device),
             text: TextPass::new(device, format),
             display_bgl,
             trilinear_sampler,
@@ -213,6 +541,10 @@ impl ModifierPipeline {
             width,
             height,
         }
+    }
+
+    pub fn reprocess_pending(&self) -> bool {
+        self.reprocess_pending
     }
 
     pub fn tile_display_bg(&self, i: usize, nearest: bool) -> Option<&BindGroup> {
@@ -232,6 +564,9 @@ impl ModifierPipeline {
         if stale(&self.scratch_b) {
             self.scratch_b = Some(ScratchTarget::new(device, self.format, w, h));
         }
+        if stale(&self.scratch_blur) {
+            self.scratch_blur = Some(ScratchTarget::new(device, self.format, w, h));
+        }
     }
 
     pub fn prepare(
@@ -244,9 +579,12 @@ impl ModifierPipeline {
     ) {
         let n_tiles = source.tiles.len();
 
+        self.reprocess_pending = false;
+
         self.tile_outputs.resize_with(n_tiles, || None);
         self.tile_display_bgs_linear.resize_with(n_tiles, || None);
         self.tile_display_bgs_nearest.resize_with(n_tiles, || None);
+        self.roi_display_uniforms.resize_with(n_tiles, || None);
 
         if dirty {
             for o in self.tile_outputs.iter_mut().flatten() {
@@ -302,11 +640,37 @@ impl ModifierPipeline {
             }
         }
 
-        let mut plan: Option<Vec<PlanItem>> = None;
+        let plan_vec = plan_modifiers(modifiers);
+        let has_blur = plan_vec
+            .iter()
+            .any(|p| matches!(p, PlanItem::Step(_, m) if m.kind.input_request().neighborhood_radius().is_some()));
+        let has_pixel_sort = plan_vec.iter().any(
+            |p| matches!(p, PlanItem::Step(_, m) if matches!(m.kind, ModifierKind::PixelSort(_))),
+        );
+
+        if n_tiles > 1 && (has_blur || has_pixel_sort) {
+            self.prepare_tiled(
+                device,
+                queue,
+                source,
+                &plan_vec,
+                proc_scale,
+                downscale,
+                dirty,
+                has_pixel_sort,
+            );
+            return;
+        }
+
+        let roi_ok = plan_vec.iter().all(|p| matches!(p, PlanItem::Fused(_)));
+
+        let mut plan: Option<Vec<PlanItem>> = Some(plan_vec);
         let mut encoder: Option<CommandEncoder> = None;
         let mut pool_used = 0usize;
         let mut ca_pool_used = 0usize;
+        let mut blur_pool_used = 0usize;
         let mut text_pool_used = 0usize;
+        let mut scheduler = Scheduler::new();
 
         for ti in 0..n_tiles {
             let tile = &source.tiles[ti];
@@ -318,28 +682,50 @@ impl ModifierPipeline {
                 continue;
             }
 
-            let eff_w = if downscale {
-                ((tile.width as f32 * proc_scale).ceil() as u32).max(1)
-            } else {
-                tile.width
-            };
-            let eff_h = if downscale {
-                ((tile.height as f32 * proc_scale).ceil() as u32).max(1)
-            } else {
-                tile.height
+            let cur_scale = if downscale { proc_scale } else { 1.0 };
+            let visible_roi = if roi_ok { tile.proc_rect_px } else { None };
+            let reuse = match (self.tile_outputs[ti].as_ref(), visible_roi) {
+                (Some(o), Some(roi)) => {
+                    o.proc_px.is_some_and(|p| rect_contains(p, roi))
+                        && (o.proc_scale - cur_scale).abs() < 1e-4
+                }
+                (Some(o), None) => o.proc_px.is_none() && (o.proc_scale - cur_scale).abs() < 1e-4,
+                _ => false,
             };
 
-            let needs_alloc = self.tile_outputs[ti]
-                .as_ref()
-                .is_none_or(|o| o.width != eff_w || o.height != eff_h);
+            let pr = if reuse {
+                let o = self.tile_outputs[ti].as_ref().unwrap();
+                proc_rect_from_px(
+                    o.proc_px,
+                    tile,
+                    source.full_width as f32,
+                    source.full_height as f32,
+                    o.width,
+                    o.height,
+                )
+            } else {
+                tile_proc_rect(
+                    tile,
+                    source.full_width as f32,
+                    source.full_height as f32,
+                    proc_scale,
+                    downscale,
+                    0.0,
+                    roi_ok,
+                )
+            };
+            let (eff_w, eff_h) = (pr.w, pr.h);
 
-            if needs_alloc {
+            if !reuse {
                 let tex = gpu::texture_2d(
                     device,
                     eff_w,
                     eff_h,
                     self.format,
-                    TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+                    TextureUsages::RENDER_ATTACHMENT
+                        | TextureUsages::TEXTURE_BINDING
+                        | TextureUsages::COPY_SRC
+                        | TextureUsages::COPY_DST,
                     Some(&format!("modifier-tile{ti}-output")),
                 );
                 let view = tex.create_view(&Default::default());
@@ -349,15 +735,24 @@ impl ModifierPipeline {
                     valid: false,
                     width: eff_w,
                     height: eff_h,
+                    proc_px: if roi_ok { Some(pr.px) } else { None },
+                    proc_scale: cur_scale,
+                    band_y: 0,
                 });
                 self.tile_display_bgs_linear[ti] = None;
                 self.tile_display_bgs_nearest[ti] = None;
             }
 
             let needs_reprocess = !self.tile_outputs[ti].as_ref().unwrap().valid;
-            let needs_bg_rebuild = self.tile_display_bgs_linear[ti].is_none() || needs_reprocess;
+            let roi_active = roi_ok && tile.isec_px.is_some();
+            let needs_bg_rebuild =
+                self.tile_display_bgs_linear[ti].is_none() || needs_reprocess || roi_active;
 
             if !needs_bg_rebuild {
+                continue;
+            }
+
+            if needs_reprocess && !scheduler.admit() {
                 continue;
             }
 
@@ -373,26 +768,30 @@ impl ModifierPipeline {
 
                 let plan = plan.get_or_insert_with(|| plan_modifiers(modifiers));
                 let n_items = plan.len();
-                if n_items > 1 {
+                let plan_has_blur = plan.iter().any(|p| {
+                    matches!(p, PlanItem::Step(_, m) if m.kind.input_request().neighborhood_radius().is_some())
+                });
+                if n_items > 1 || plan_has_blur {
                     self.ensure_scratch(device, eff_w, eff_h);
                 }
 
-                let combined = &self.combined;
-                let sampler = &self.trilinear_sampler;
-                let output_view = &self.tile_outputs[ti].as_ref().unwrap().view;
-                let mut prev: &TextureView = &tile.source_view;
+                let mut prev: TextureView = tile.source_view.clone();
                 for (k, item) in plan.iter().enumerate() {
-                    let out: &TextureView = if k == n_items - 1 {
-                        output_view
+                    let out: TextureView = if k == n_items - 1 {
+                        self.tile_outputs[ti].as_ref().unwrap().view.clone()
                     } else if k % 2 == 0 {
-                        &self.scratch_a.as_ref().unwrap().view
+                        self.scratch_a.as_ref().unwrap().view.clone()
                     } else {
-                        &self.scratch_b.as_ref().unwrap().view
+                        self.scratch_b.as_ref().unwrap().view.clone()
                     };
+                    let out = &out;
+
+                    let src_rect = if k == 0 { pr.src } else { pr.proc };
 
                     match item {
                         PlanItem::Fused(seg) => {
-                            let uniforms = build_segment_uniforms(seg, &tile_info);
+                            let uniforms =
+                                build_segment_uniforms(seg, &tile_info, pr.proc, src_rect);
                             if pool_used == self.uniform_pool.len() {
                                 self.uniform_pool.push(gpu::uniform_buffer::<ModUniforms>(
                                     device,
@@ -404,10 +803,10 @@ impl ModifierPipeline {
                             gpu::write_uniform(queue, buffer, &uniforms);
                             let bg = gpu::standard_bind_group(
                                 device,
-                                &combined.bgl,
+                                &self.combined.bgl,
                                 buffer,
-                                prev,
-                                sampler,
+                                &prev,
+                                &self.trilinear_sampler,
                                 Some("combined-modifiers-bg"),
                             );
 
@@ -418,7 +817,78 @@ impl ModifierPipeline {
                                     },
                                 )
                             });
-                            combined.run(enc, &bg, out);
+                            self.combined.run(enc, &bg, out);
+                        }
+                        PlanItem::Step(idx, m)
+                            if m.kind.input_request().neighborhood_radius().is_some() =>
+                        {
+                            let radius = m.kind.input_request().neighborhood_radius().unwrap();
+                            {
+                                while self.blur_uniform_pool.len() < blur_pool_used + 2 {
+                                    self.blur_uniform_pool
+                                        .push(self.gaussian_blur.uniform_buffer(device));
+                                }
+                                let radius_px = radius * eff_w as f32 / tile.width.max(1) as f32;
+                                let sigma = (radius_px / 3.0).max(0.5);
+                                let step_x = tile.width.max(1) as f32 / eff_w as f32;
+                                let step_y = tile.height.max(1) as f32 / eff_h as f32;
+                                let mid = &self.scratch_blur.as_ref().unwrap().view;
+                                let enc = encoder.get_or_insert_with(|| {
+                                    device.create_command_encoder(
+                                        &iced::wgpu::CommandEncoderDescriptor {
+                                            label: Some("modifier-pipeline-encoder"),
+                                        },
+                                    )
+                                });
+                                let (h_pool, v_pool) =
+                                    self.blur_uniform_pool.split_at(blur_pool_used + 1);
+                                let h_buffer = &h_pool[blur_pool_used];
+                                let v_buffer = &v_pool[0];
+                                blur_pool_used += 2;
+                                let proc = TileRect {
+                                    origin: pr.proc.origin,
+                                    size: pr.proc.size,
+                                };
+                                let src0 = TileRect {
+                                    origin: pr.src.origin,
+                                    size: pr.src.size,
+                                };
+                                let src_lod = step_x.max(1.0).log2();
+                                self.gaussian_blur.record(
+                                    device,
+                                    queue,
+                                    enc,
+                                    h_buffer,
+                                    [step_x / source.full_width as f32, 0.0],
+                                    radius_px,
+                                    sigma,
+                                    proc,
+                                    src0,
+                                    None,
+                                    None,
+                                    &prev,
+                                    mid,
+                                    None,
+                                    src_lod,
+                                );
+                                self.gaussian_blur.record(
+                                    device,
+                                    queue,
+                                    enc,
+                                    v_buffer,
+                                    [0.0, step_y / source.full_height as f32],
+                                    radius_px,
+                                    sigma,
+                                    proc,
+                                    proc,
+                                    None,
+                                    None,
+                                    mid,
+                                    out,
+                                    None,
+                                    0.0,
+                                );
+                            }
                         }
                         PlanItem::Step(idx, m) => match &m.kind {
                             ModifierKind::ChromaticAberration(ca) => {
@@ -436,8 +906,18 @@ impl ModifierPipeline {
                                         },
                                     )
                                 });
+                                let src_rect = if k == 0 { pr.src } else { pr.proc };
                                 self.chromatic_aberration.record(
-                                    device, queue, enc, buffer, amount, &tile_info, prev, out,
+                                    device,
+                                    queue,
+                                    enc,
+                                    buffer,
+                                    amount,
+                                    source.full_width as f32,
+                                    pr.proc,
+                                    src_rect,
+                                    &prev,
+                                    out,
                                 );
                             }
                             ModifierKind::Text(_) => {
@@ -457,8 +937,56 @@ impl ModifierPipeline {
                                             },
                                         )
                                     });
+                                    let src_rect = if k == 0 { pr.src } else { pr.proc };
                                     self.text.record(
-                                        device, queue, enc, buffer, layer, &tile_info, prev, out,
+                                        device, queue, enc, buffer, layer, &tile_info, pr.proc,
+                                        src_rect, &prev, out,
+                                    );
+                                }
+                            }
+                            ModifierKind::PixelSort(ps) => {
+                                let (threshold, angle) = (ps.threshold, ps.angle);
+                                let src_rect = if k == 0 { pr.src } else { pr.proc };
+                                let uniforms =
+                                    build_segment_uniforms(&[], &tile_info, pr.proc, src_rect);
+                                if pool_used == self.uniform_pool.len() {
+                                    self.uniform_pool.push(gpu::uniform_buffer::<ModUniforms>(
+                                        device,
+                                        Some("combined-modifiers-uniform"),
+                                    ));
+                                }
+                                let buffer = &self.uniform_pool[pool_used];
+                                pool_used += 1;
+                                gpu::write_uniform(queue, buffer, &uniforms);
+                                let bg = gpu::standard_bind_group(
+                                    device,
+                                    &self.combined.bgl,
+                                    buffer,
+                                    &prev,
+                                    &self.trilinear_sampler,
+                                    Some("pixel-sort-copy-bg"),
+                                );
+                                let enc = encoder.get_or_insert_with(|| {
+                                    device.create_command_encoder(
+                                        &iced::wgpu::CommandEncoderDescriptor {
+                                            label: Some("modifier-pipeline-encoder"),
+                                        },
+                                    )
+                                });
+                                self.combined.run(enc, &bg, out);
+                                if n_tiles == 1 {
+                                    if let Some(enc) = encoder.take() {
+                                        queue.submit([enc.finish()]);
+                                    }
+                                    let target = if k == n_items - 1 {
+                                        SortTarget::Output
+                                    } else if k % 2 == 0 {
+                                        SortTarget::ScratchA
+                                    } else {
+                                        SortTarget::ScratchB
+                                    };
+                                    self.sort_target(
+                                        device, queue, ti, target, eff_w, eff_h, threshold, angle,
                                     );
                                 }
                             }
@@ -466,47 +994,1657 @@ impl ModifierPipeline {
                         },
                     }
 
-                    prev = out;
+                    prev = out.clone();
                 }
 
                 self.tile_outputs[ti].as_mut().unwrap().valid = true;
             }
 
-            let output_view = &self.tile_outputs[ti].as_ref().unwrap().view;
-
-            let make_bg = |sampler: &Sampler, label: &str| {
-                device.create_bind_group(&BindGroupDescriptor {
-                    label: Some(label),
-                    layout: &self.display_bgl,
-                    entries: &[
-                        BindGroupEntry {
-                            binding: 0,
-                            resource: tile.uniform_buffer.as_entire_binding(),
-                        },
-                        BindGroupEntry {
-                            binding: 1,
-                            resource: BindingResource::TextureView(output_view),
-                        },
-                        BindGroupEntry {
-                            binding: 2,
-                            resource: BindingResource::Sampler(sampler),
-                        },
-                    ],
-                })
-            };
-
-            self.tile_display_bgs_linear[ti] = Some(make_bg(
-                &self.linear_sampler,
-                &format!("modifier-tile{ti}-display-linear"),
-            ));
-            self.tile_display_bgs_nearest[ti] = Some(make_bg(
-                &self.nearest_sampler,
-                &format!("modifier-tile{ti}-display-nearest"),
-            ));
+            self.build_roi_display_bgs(device, queue, ti, tile, &pr, roi_ok);
         }
+
+        self.reprocess_pending |= scheduler.pending();
 
         if let Some(encoder) = encoder {
             queue.submit([encoder.finish()]);
         }
+    }
+
+    fn ensure_tile_output(
+        &mut self,
+        device: &Device,
+        ti: usize,
+        w: u32,
+        h: u32,
+        proc_px: Option<[f32; 4]>,
+    ) {
+        let needs_alloc = self.tile_outputs[ti]
+            .as_ref()
+            .is_none_or(|o| o.width != w || o.height != h);
+        if needs_alloc {
+            let tex = gpu::texture_2d(
+                device,
+                w,
+                h,
+                self.format,
+                TextureUsages::RENDER_ATTACHMENT
+                    | TextureUsages::TEXTURE_BINDING
+                    | TextureUsages::COPY_SRC
+                    | TextureUsages::COPY_DST,
+                Some(&format!("modifier-tile{ti}-output")),
+            );
+            let view = tex.create_view(&Default::default());
+            self.tile_outputs[ti] = Some(TileOutput {
+                _tex: tex,
+                view,
+                valid: false,
+                width: w,
+                height: h,
+                proc_px,
+                proc_scale: 1.0,
+                band_y: 0,
+            });
+            self.tile_display_bgs_linear[ti] = None;
+            self.tile_display_bgs_nearest[ti] = None;
+        }
+    }
+
+    pub fn refresh_display_transforms(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        source: &TiledSource,
+    ) {
+        let full_w = source.full_width as f32;
+        let full_h = source.full_height as f32;
+        for ti in 0..source.tiles.len() {
+            let tile = &source.tiles[ti];
+            if tile_ndc_culled(tile.last_ndc_rect) {
+                continue;
+            }
+            let Some(o) = self.tile_outputs[ti].as_ref() else {
+                continue;
+            };
+            if !o.valid {
+                continue;
+            }
+            let (proc_px, w, h) = (o.proc_px, o.width, o.height);
+            let pr = proc_rect_from_px(proc_px, tile, full_w, full_h, w, h);
+            let roi_active = proc_px.is_some() && tile.isec_px.is_some();
+            self.build_roi_display_bgs(device, queue, ti, tile, &pr, roi_active);
+        }
+    }
+
+    fn build_roi_display_bgs(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        ti: usize,
+        tile: &crate::wgpu::tiled_source::Tile,
+        pr: &ProcRect,
+        roi_active: bool,
+    ) {
+        let display_uniform: &iced::wgpu::Buffer = if roi_active
+            && let (Some(isec), Some(base)) = (tile.isec_px, tile.last_transform)
+        {
+            let t = inscribe_transform(base, isec, pr.px);
+            if self.roi_display_uniforms[ti].is_none() {
+                self.roi_display_uniforms[ti] =
+                    Some(gpu::uniform_buffer::<
+                        crate::wgpu::view_pipeline::DisplayUniforms,
+                    >(device, Some("roi-display-uniform")));
+            }
+            let buf = self.roi_display_uniforms[ti].as_ref().unwrap();
+            gpu::write_uniform(
+                queue,
+                buf,
+                &crate::wgpu::view_pipeline::DisplayUniforms {
+                    transform: t,
+                    crop_uv: [0.0, 0.0, 1.0, 1.0],
+                },
+            );
+            buf
+        } else {
+            &tile.uniform_buffer
+        };
+
+        let output_view = &self.tile_outputs[ti].as_ref().unwrap().view;
+        let make_bg = |sampler: &Sampler, label: &str| {
+            device.create_bind_group(&BindGroupDescriptor {
+                label: Some(label),
+                layout: &self.display_bgl,
+                entries: &[
+                    BindGroupEntry {
+                        binding: 0,
+                        resource: display_uniform.as_entire_binding(),
+                    },
+                    BindGroupEntry {
+                        binding: 1,
+                        resource: BindingResource::TextureView(output_view),
+                    },
+                    BindGroupEntry {
+                        binding: 2,
+                        resource: BindingResource::Sampler(sampler),
+                    },
+                ],
+            })
+        };
+        self.tile_display_bgs_linear[ti] = Some(make_bg(
+            &self.linear_sampler,
+            &format!("modifier-tile{ti}-display-linear"),
+        ));
+        self.tile_display_bgs_nearest[ti] = Some(make_bg(
+            &self.nearest_sampler,
+            &format!("modifier-tile{ti}-display-nearest"),
+        ));
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_tiled(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        source: &TiledSource,
+        plan: &[PlanItem],
+        proc_scale: f32,
+        downscale: bool,
+        dirty: bool,
+        has_pixel_sort: bool,
+    ) {
+        if has_pixel_sort {
+            self.prepare_tiled_scanlines(device, queue, source, plan, proc_scale, dirty);
+            return;
+        }
+
+        let n_tiles = source.tiles.len();
+        self.bank_a.resize_with(n_tiles, || None);
+        self.bank_b.resize_with(n_tiles, || None);
+        self.blur_hmid.resize_with(n_tiles, || None);
+        self.blur_vstrip_top.resize_with(n_tiles, || None);
+        self.blur_vstrip_bot.resize_with(n_tiles, || None);
+
+        let full_w = source.full_width as f32;
+        let full_h = source.full_height as f32;
+
+        let mut apron_px: f32 = 0.0;
+        for item in plan {
+            if let PlanItem::Step(_, m) = item
+                && let Some(radius) = m.kind.input_request().neighborhood_radius()
+            {
+                apron_px = apron_px.max(radius);
+            }
+        }
+
+        let blur_is_sole_step = plan.len() == 1
+            && matches!(
+                plan.first(),
+                Some(PlanItem::Step(_, m)) if m.kind.input_request().neighborhood_radius().is_some()
+            );
+
+        let roi_active = !downscale
+            && blur_is_sole_step
+            && source
+                .tiles
+                .iter()
+                .any(|t| !tile_ndc_culled(t.last_ndc_rect))
+            && source
+                .tiles
+                .iter()
+                .all(|t| tile_ndc_culled(t.last_ndc_rect) || t.proc_rect_px.is_some());
+
+        let (mut proc_scale, mut downscale) = (proc_scale, downscale);
+        if !roi_active {
+            let mut in_set = vec![false; n_tiles];
+            for ti in 0..n_tiles {
+                if tile_ndc_culled(source.tiles[ti].last_ndc_rect) {
+                    continue;
+                }
+                in_set[ti] = true;
+                let nb = tile_neighbors(&source.tiles, ti);
+                for nn in [nb.left, nb.right, nb.up, nb.down].into_iter().flatten() {
+                    in_set[nn] = true;
+                }
+            }
+            let mut n_proc = 0u64;
+            let mut tw = 1u32;
+            let mut th = 1u32;
+            for (ti, &keep) in in_set.iter().enumerate() {
+                if keep {
+                    n_proc += 1;
+                    tw = tw.max(source.tiles[ti].width);
+                    th = th.max(source.tiles[ti].height);
+                }
+            }
+            let fit = fit_process_scale(tw, th, n_proc, 3, process_vram_budget(device), proc_scale);
+            if fit < proc_scale {
+                proc_scale = fit;
+                downscale = true;
+            }
+        }
+
+        let proc_rect_for =
+            |ti: usize, reuse: bool, prev_px: Option<[f32; 4]>, prev_wh: (u32, u32)| -> ProcRect {
+                if reuse {
+                    proc_rect_from_px(
+                        prev_px,
+                        &source.tiles[ti],
+                        full_w,
+                        full_h,
+                        prev_wh.0,
+                        prev_wh.1,
+                    )
+                } else {
+                    tile_proc_rect(
+                        &source.tiles[ti],
+                        full_w,
+                        full_h,
+                        proc_scale,
+                        downscale,
+                        apron_px,
+                        roi_active,
+                    )
+                }
+            };
+
+        let cur_scale = if downscale { proc_scale } else { 1.0 };
+
+        let mut proc_rects: Vec<Option<ProcRect>> = (0..n_tiles).map(|_| None).collect();
+        let mut stale: Vec<usize> = Vec::new();
+        #[allow(clippy::needless_range_loop)]
+        for ti in 0..n_tiles {
+            let tile = &source.tiles[ti];
+            if tile_ndc_culled(tile.last_ndc_rect) {
+                self.tile_outputs[ti] = None;
+                self.tile_display_bgs_linear[ti] = None;
+                self.tile_display_bgs_nearest[ti] = None;
+                continue;
+            }
+            let roi = if roi_active { tile.proc_rect_px } else { None };
+            let (prev_px, prev_scale, prev_wh) = self.tile_outputs[ti]
+                .as_ref()
+                .map(|o| (o.proc_px, o.proc_scale, (o.width, o.height)))
+                .unwrap_or((None, 0.0, (0, 0)));
+            let same_scale = (prev_scale - cur_scale).abs() < 1e-4;
+            let reuse_valid = !dirty
+                && match (prev_px, roi) {
+                    (Some(p), Some(r)) => rect_contains(p, r) && same_scale,
+                    (None, None) => same_scale,
+                    _ => false,
+                };
+            let pr = proc_rect_for(ti, reuse_valid, prev_px, prev_wh);
+            self.ensure_tile_output(
+                device,
+                ti,
+                pr.w,
+                pr.h,
+                if roi_active { Some(pr.px) } else { None },
+            );
+            if !reuse_valid {
+                let o = self.tile_outputs[ti].as_mut().unwrap();
+                o.valid = false;
+                o.proc_px = if roi_active { Some(pr.px) } else { None };
+                o.band_y = 0;
+            }
+            self.tile_outputs[ti].as_mut().unwrap().proc_scale = cur_scale;
+
+            let needs = !self.tile_outputs[ti].as_ref().is_some_and(|o| o.valid)
+                || self.tile_display_bgs_linear[ti].is_none()
+                || !reuse_valid
+                || (roi_active && tile.isec_px.is_some());
+            if needs {
+                stale.push(ti);
+            }
+            proc_rects[ti] = Some(pr);
+        }
+
+        if stale.is_empty() {
+            return;
+        }
+
+        let mut scheduler = Scheduler::new();
+        let mut reprocess: Vec<usize> = Vec::new();
+        let mut display_set: Vec<usize> = Vec::new();
+        for &ti in &stale {
+            let needs_reprocess = !self.tile_outputs[ti].as_ref().is_some_and(|o| o.valid);
+            if needs_reprocess {
+                if !scheduler.admit() {
+                    continue;
+                }
+                reprocess.push(ti);
+            }
+            display_set.push(ti);
+        }
+        self.reprocess_pending = scheduler.pending();
+
+        let mut in_process = vec![false; n_tiles];
+        let mut blur_set: Vec<usize> = Vec::new();
+        for &ti in &reprocess {
+            if !in_process[ti] {
+                in_process[ti] = true;
+                blur_set.push(ti);
+            }
+            if !roi_active {
+                let nb = tile_neighbors(&source.tiles, ti);
+                for n in [nb.left, nb.right, nb.up, nb.down].into_iter().flatten() {
+                    if !in_process[n] {
+                        in_process[n] = true;
+                        blur_set.push(n);
+                        if proc_rects[n].is_none() {
+                            proc_rects[n] = Some(tile_proc_rect(
+                                &source.tiles[n],
+                                full_w,
+                                full_h,
+                                proc_scale,
+                                downscale,
+                                apron_px,
+                                false,
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        let ensure_bank = |bank: &mut Vec<Option<ScratchTarget>>,
+                           ti: usize,
+                           w: u32,
+                           h: u32,
+                           fmt: TextureFormat| {
+            let stale = bank[ti]
+                .as_ref()
+                .is_none_or(|t| t.width != w || t.height != h);
+            if stale {
+                bank[ti] = Some(ScratchTarget::new(device, fmt, w, h));
+            }
+        };
+        for &ti in &blur_set {
+            let pr = proc_rects[ti].as_ref().unwrap();
+            self.ensure_tile_output(
+                device,
+                ti,
+                pr.w,
+                pr.h,
+                if roi_active { Some(pr.px) } else { None },
+            );
+            ensure_bank(&mut self.bank_a, ti, pr.w, pr.h, self.format);
+            ensure_bank(&mut self.bank_b, ti, pr.w, pr.h, self.format);
+            ensure_bank(&mut self.blur_hmid, ti, pr.w, pr.h, self.format);
+        }
+
+        let plan_steps = plan.len();
+        let mut encoder = device.create_command_encoder(&iced::wgpu::CommandEncoderDescriptor {
+            label: Some("modifier-step-major-encoder"),
+        });
+        let mut pools = StepPools::default();
+        let mut blur_pool_used = 0usize;
+
+        let mut prev_in_a = true;
+
+        for (k, item) in plan.iter().enumerate() {
+            let last = k == plan_steps - 1;
+            let is_blur = matches!(item, PlanItem::Step(_, m) if m.kind.input_request().neighborhood_radius().is_some());
+            if !is_blur {
+                for &ti in &blur_set {
+                    let tile = &source.tiles[ti];
+                    let pr = proc_rects[ti].as_ref().unwrap();
+                    let tile_info = TileInfo {
+                        tile_x: tile.x,
+                        tile_y: tile.y,
+                        tile_w: tile.width,
+                        tile_h: tile.height,
+                        full_w: source.full_width,
+                        full_h: source.full_height,
+                    };
+
+                    let prev: TextureView = if k == 0 {
+                        tile.source_view.clone()
+                    } else if prev_in_a {
+                        self.bank_a[ti].as_ref().unwrap().view.clone()
+                    } else {
+                        self.bank_b[ti].as_ref().unwrap().view.clone()
+                    };
+
+                    let dst_in_a = !prev_in_a;
+                    let out: TextureView = if last {
+                        self.tile_outputs[ti].as_ref().unwrap().view.clone()
+                    } else if dst_in_a {
+                        self.bank_a[ti].as_ref().unwrap().view.clone()
+                    } else {
+                        self.bank_b[ti].as_ref().unwrap().view.clone()
+                    };
+
+                    let src_rect = if k == 0 { pr.src } else { pr.proc };
+                    let proc = pr.proc;
+                    self.run_ordinary_step(
+                        device,
+                        queue,
+                        &mut encoder,
+                        item,
+                        &tile_info,
+                        source.full_width as f32,
+                        proc,
+                        src_rect,
+                        &prev,
+                        &out,
+                        &mut pools,
+                    );
+                }
+            }
+
+            if let PlanItem::Step(_, m) = item
+                && let Some(radius) = m.kind.input_request().neighborhood_radius()
+            {
+                let deferred = self.run_separable_step(
+                    device,
+                    queue,
+                    &mut encoder,
+                    source,
+                    &blur_set,
+                    &proc_rects,
+                    roi_active,
+                    radius,
+                    k == 0,
+                    prev_in_a,
+                    last,
+                    &mut blur_pool_used,
+                );
+                self.reprocess_pending |= deferred;
+            }
+
+            if !last {
+                prev_in_a = !prev_in_a;
+            }
+        }
+
+        for &ti in &reprocess {
+            let o = self.tile_outputs[ti].as_mut().unwrap();
+            let complete = o.band_y == 0 || o.band_y >= o.height;
+            o.valid = complete;
+        }
+        for &ti in &display_set {
+            let pr = proc_rects[ti].as_ref().unwrap();
+            self.build_roi_display_bgs(device, queue, ti, &source.tiles[ti], pr, roi_active);
+        }
+        queue.submit([encoder.finish()]);
+    }
+
+    fn prepare_tiled_scanlines(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        source: &TiledSource,
+        plan: &[PlanItem],
+        proc_scale: f32,
+        dirty: bool,
+    ) {
+        let n_tiles = source.tiles.len();
+        self.bank_a.resize_with(n_tiles, || None);
+        self.bank_b.resize_with(n_tiles, || None);
+        self.blur_hmid.resize_with(n_tiles, || None);
+
+        let scale = fit_process_scale(
+            source.full_width,
+            source.full_height,
+            1,
+            3,
+            process_vram_budget(device),
+            proc_scale,
+        );
+        let stile = |ti: usize, source: &TiledSource| -> (u32, u32, u32, u32) {
+            let t = &source.tiles[ti];
+            let sx0 = scaled(t.x, scale);
+            let sy0 = scaled(t.y, scale);
+            let sx1 = scaled(t.x + t.width, scale);
+            let sy1 = scaled(t.y + t.height, scale);
+            (sx0, sy0, (sx1 - sx0).max(1), (sy1 - sy0).max(1))
+        };
+
+        let mut has_h = false;
+        let mut has_v = false;
+        for p in plan {
+            if let PlanItem::Step(_, m) = p
+                && let ModifierKind::PixelSort(ps) = &m.kind
+            {
+                match SortAxis::from_angle(ps.angle) {
+                    SortAxis::Vertical { .. } => has_v = true,
+                    SortAxis::Horizontal { .. } => has_h = true,
+                }
+            }
+        }
+
+        let visible: Vec<usize> = (0..n_tiles)
+            .filter(|&ti| !tile_ndc_culled(source.tiles[ti].last_ndc_rect))
+            .collect();
+        if visible.is_empty() {
+            for ti in 0..n_tiles {
+                self.tile_outputs[ti] = None;
+                self.tile_display_bgs_linear[ti] = None;
+                self.tile_display_bgs_nearest[ti] = None;
+            }
+            return;
+        }
+
+        let plan_has_blur = plan
+            .iter()
+            .any(|p| matches!(p, PlanItem::Step(_, m) if m.kind.input_request().neighborhood_radius().is_some()));
+
+        let mut in_set = vec![false; n_tiles];
+        for &v in &visible {
+            let (vx, vy) = (source.tiles[v].x, source.tiles[v].y);
+            for (ti, slot) in in_set.iter_mut().enumerate() {
+                let same_row = source.tiles[ti].y == vy;
+                let same_col = source.tiles[ti].x == vx;
+                if (has_h && same_row) || (has_v && same_col) {
+                    *slot = true;
+                }
+            }
+        }
+        if plan_has_blur {
+            let strip: Vec<usize> = (0..n_tiles).filter(|&ti| in_set[ti]).collect();
+            for ti in strip {
+                let nb = tile_neighbors(&source.tiles, ti);
+                for n in [nb.left, nb.right, nb.up, nb.down].into_iter().flatten() {
+                    in_set[n] = true;
+                }
+            }
+            let expanded: Vec<usize> = (0..n_tiles).filter(|&ti| in_set[ti]).collect();
+            for ei in expanded {
+                let (ex, ey) = (source.tiles[ei].x, source.tiles[ei].y);
+                for (ti, slot) in in_set.iter_mut().enumerate() {
+                    let same_row = source.tiles[ti].y == ey;
+                    let same_col = source.tiles[ti].x == ex;
+                    if (has_h && same_row) || (has_v && same_col) {
+                        *slot = true;
+                    }
+                }
+            }
+        }
+        let proc_set: Vec<usize> = (0..n_tiles).filter(|&ti| in_set[ti]).collect();
+
+        for (ti, &keep) in in_set.iter().enumerate() {
+            if !keep {
+                self.tile_outputs[ti] = None;
+                self.tile_display_bgs_linear[ti] = None;
+                self.tile_display_bgs_nearest[ti] = None;
+                self.bank_a[ti] = None;
+                self.bank_b[ti] = None;
+            }
+        }
+
+        if dirty {
+            for &ti in &proc_set {
+                if let Some(o) = self.tile_outputs[ti].as_mut() {
+                    o.valid = false;
+                }
+            }
+        }
+
+        let ensure_bank = |bank: &mut Vec<Option<ScratchTarget>>,
+                           ti: usize,
+                           w: u32,
+                           h: u32,
+                           fmt: TextureFormat| {
+            let stale = bank[ti]
+                .as_ref()
+                .is_none_or(|t| t.width != w || t.height != h);
+            if stale {
+                bank[ti] = Some(ScratchTarget::new(device, fmt, w, h));
+            }
+        };
+
+        let plan_steps = plan.len();
+
+        let mut proc_rects: Vec<Option<ProcRect>> = (0..n_tiles).map(|_| None).collect();
+        for &ti in &proc_set {
+            let (_, _, sw, sh) = stile(ti, source);
+            self.ensure_tile_output(device, ti, sw, sh, None);
+            ensure_bank(&mut self.bank_a, ti, sw, sh, self.format);
+            ensure_bank(&mut self.bank_b, ti, sw, sh, self.format);
+            if plan_has_blur {
+                ensure_bank(&mut self.blur_hmid, ti, sw, sh, self.format);
+                let t = &source.tiles[ti];
+                let fw = source.full_width as f32;
+                let fh = source.full_height as f32;
+                proc_rects[ti] = Some(ProcRect {
+                    px: [
+                        t.x as f32,
+                        t.y as f32,
+                        (t.x + t.width) as f32,
+                        (t.y + t.height) as f32,
+                    ],
+                    proc: UvRect {
+                        origin: [t.x as f32 / fw, t.y as f32 / fh],
+                        size: [t.width as f32 / fw, t.height as f32 / fh],
+                    },
+                    src: UvRect {
+                        origin: [t.x as f32 / fw, t.y as f32 / fh],
+                        size: [t.width as f32 / fw, t.height as f32 / fh],
+                    },
+                    w: sw,
+                    h: sh,
+                });
+            }
+        }
+
+        let all_valid = proc_set
+            .iter()
+            .all(|&ti| self.tile_outputs[ti].as_ref().is_some_and(|o| o.valid));
+        let needs_bg_only = all_valid && !dirty;
+
+        let mut sig: u64 = 1469598103934665603;
+        for &ti in &proc_set {
+            sig = (sig ^ ti as u64).wrapping_mul(1099511628211);
+        }
+        sig = (sig ^ scale.to_bits() as u64).wrapping_mul(1099511628211);
+        if dirty || sig != self.sort_progress_sig {
+            self.sort_band_cursor = 0;
+            self.sort_progress_sig = sig;
+        }
+
+        let last_sort_k = plan.iter().enumerate().rev().find_map(|(k, p)| {
+            matches!(p, PlanItem::Step(_, m) if matches!(m.kind, ModifierKind::PixelSort(_)))
+                .then_some(k)
+        });
+
+        let continuation = self.sort_band_cursor > 0;
+
+        if !needs_bg_only {
+            let mut encoder =
+                device.create_command_encoder(&iced::wgpu::CommandEncoderDescriptor {
+                    label: Some("pixel-sort-multitile-encoder"),
+                });
+
+            if self.uniform_pool.is_empty() {
+                self.uniform_pool.push(gpu::uniform_buffer::<ModUniforms>(
+                    device,
+                    Some("combined-modifiers-uniform"),
+                ));
+            }
+            for &ti in &proc_set {
+                if continuation {
+                    break;
+                }
+                let src: TextureView = source.tiles[ti].source_view.clone();
+                let dst: TextureView = self.bank_a[ti].as_ref().unwrap().view.clone();
+                let uniforms = build_segment_uniforms(
+                    &[],
+                    &TileInfo {
+                        tile_x: source.tiles[ti].x,
+                        tile_y: source.tiles[ti].y,
+                        tile_w: source.tiles[ti].width,
+                        tile_h: source.tiles[ti].height,
+                        full_w: source.full_width,
+                        full_h: source.full_height,
+                    },
+                    UvRect {
+                        origin: [0.0, 0.0],
+                        size: [1.0, 1.0],
+                    },
+                    UvRect {
+                        origin: [0.0, 0.0],
+                        size: [1.0, 1.0],
+                    },
+                );
+                let buffer = &self.uniform_pool[0];
+                gpu::write_uniform(queue, buffer, &uniforms);
+                let bg = gpu::standard_bind_group(
+                    device,
+                    &self.combined.bgl,
+                    buffer,
+                    &src,
+                    &self.trilinear_sampler,
+                    Some("psort-downscale-bg"),
+                );
+                self.combined.run(&mut encoder, &bg, &dst);
+            }
+
+            let mut pools = StepPools {
+                fused: 1,
+                ..StepPools::default()
+            };
+            let mut blur_pool_used = 0usize;
+            let mut prev_in_a = true;
+            let mut sort_complete = true;
+
+            for (k, item) in plan.iter().enumerate() {
+                let last = k == plan_steps - 1;
+                let is_sort = matches!(item, PlanItem::Step(_, m) if matches!(m.kind, ModifierKind::PixelSort(_)));
+                let blur_radius = match item {
+                    PlanItem::Step(_, m) => m.kind.input_request().neighborhood_radius(),
+                    _ => None,
+                };
+
+                let post_sort = last_sort_k.is_some_and(|s| k > s);
+
+                if !is_sort && ((continuation && !post_sort) || (post_sort && !sort_complete)) {
+                    if !last {
+                        prev_in_a = !prev_in_a;
+                    }
+                    continue;
+                }
+
+                if let Some(radius) = blur_radius {
+                    self.run_separable_step(
+                        device,
+                        queue,
+                        &mut encoder,
+                        source,
+                        &proc_set,
+                        &proc_rects,
+                        false,
+                        radius,
+                        false,
+                        prev_in_a,
+                        last,
+                        &mut blur_pool_used,
+                    );
+                } else if !is_sort {
+                    for &ti in &proc_set {
+                        let tile = &source.tiles[ti];
+                        let tile_info = TileInfo {
+                            tile_x: tile.x,
+                            tile_y: tile.y,
+                            tile_w: tile.width,
+                            tile_h: tile.height,
+                            full_w: source.full_width,
+                            full_h: source.full_height,
+                        };
+                        let whole = tile_proc_rect(
+                            tile,
+                            source.full_width as f32,
+                            source.full_height as f32,
+                            1.0,
+                            false,
+                            0.0,
+                            false,
+                        );
+                        let prev: TextureView = self.step_input_view(ti, prev_in_a).clone();
+                        let out: TextureView = self.step_output_view(ti, last, prev_in_a).clone();
+
+                        self.run_ordinary_step(
+                            device,
+                            queue,
+                            &mut encoder,
+                            item,
+                            &tile_info,
+                            source.full_width as f32,
+                            whole.proc,
+                            whole.src,
+                            &prev,
+                            &out,
+                            &mut pools,
+                        );
+                    }
+                } else if let PlanItem::Step(_, m) = item
+                    && let ModifierKind::PixelSort(ps) = &m.kind
+                {
+                    let step_vertical =
+                        matches!(SortAxis::from_angle(ps.angle), SortAxis::Vertical { .. });
+                    let groups = pixel_sort_groups(source, &proc_set, step_vertical);
+                    queue.submit([encoder.finish()]);
+                    let budgeted = Some(k) == last_sort_k;
+                    let done = self.sort_cross_tile(
+                        device,
+                        queue,
+                        source,
+                        &groups,
+                        last,
+                        prev_in_a,
+                        step_vertical,
+                        ps.threshold,
+                        ps.angle,
+                        budgeted,
+                        scale,
+                    );
+                    if budgeted {
+                        sort_complete = done;
+                    }
+                    encoder =
+                        device.create_command_encoder(&iced::wgpu::CommandEncoderDescriptor {
+                            label: Some("pixel-sort-multitile-encoder"),
+                        });
+                }
+
+                if !last {
+                    prev_in_a = !prev_in_a;
+                }
+            }
+
+            queue.submit([encoder.finish()]);
+
+            if sort_complete {
+                self.sort_band_cursor = 0;
+                for &ti in &proc_set {
+                    if let Some(o) = self.tile_outputs[ti].as_mut() {
+                        o.valid = true;
+                    }
+                }
+            } else {
+                self.reprocess_pending = true;
+            }
+        }
+
+        let full_w = source.full_width as f32;
+        let full_h = source.full_height as f32;
+        for &ti in &visible {
+            let tile = &source.tiles[ti];
+            let pr = proc_rect_from_px(None, tile, full_w, full_h, tile.width, tile.height);
+            self.build_roi_display_bgs(device, queue, ti, tile, &pr, false);
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_ordinary_step(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        encoder: &mut CommandEncoder,
+        item: &PlanItem,
+        tile_info: &TileInfo,
+        full_w: f32,
+        proc: UvRect,
+        src: UvRect,
+        prev: &TextureView,
+        out: &TextureView,
+        pools: &mut StepPools,
+    ) {
+        match item {
+            PlanItem::Fused(seg) => {
+                let uniforms = build_segment_uniforms(seg, tile_info, proc, src);
+                if pools.fused == self.uniform_pool.len() {
+                    self.uniform_pool.push(gpu::uniform_buffer::<ModUniforms>(
+                        device,
+                        Some("combined-modifiers-uniform"),
+                    ));
+                }
+                let buffer = &self.uniform_pool[pools.fused];
+                pools.fused += 1;
+                gpu::write_uniform(queue, buffer, &uniforms);
+                let bg = gpu::standard_bind_group(
+                    device,
+                    &self.combined.bgl,
+                    buffer,
+                    prev,
+                    &self.trilinear_sampler,
+                    Some("combined-modifiers-bg"),
+                );
+                self.combined.run(encoder, &bg, out);
+            }
+            PlanItem::Step(idx, m) => match &m.kind {
+                ModifierKind::ChromaticAberration(ca) => {
+                    if pools.ca == self.ca_uniform_pool.len() {
+                        self.ca_uniform_pool
+                            .push(self.chromatic_aberration.uniform_buffer(device));
+                    }
+                    let buffer = &self.ca_uniform_pool[pools.ca];
+                    pools.ca += 1;
+                    self.chromatic_aberration.record(
+                        device, queue, encoder, buffer, ca.amount, full_w, proc, src, prev, out,
+                    );
+                }
+                ModifierKind::Text(_) => {
+                    if let Some(layer) = self.text_layers.get(*idx).and_then(|l| l.as_ref()) {
+                        if pools.text == self.text_uniform_pool.len() {
+                            self.text_uniform_pool
+                                .push(self.text.uniform_buffer(device));
+                        }
+                        let buffer = &self.text_uniform_pool[pools.text];
+                        pools.text += 1;
+                        self.text.record(
+                            device, queue, encoder, buffer, layer, tile_info, proc, src, prev, out,
+                        );
+                    }
+                }
+                _ => {
+                    let uniforms = build_segment_uniforms(&[], tile_info, proc, src);
+                    if pools.fused == self.uniform_pool.len() {
+                        self.uniform_pool.push(gpu::uniform_buffer::<ModUniforms>(
+                            device,
+                            Some("combined-modifiers-uniform"),
+                        ));
+                    }
+                    let buffer = &self.uniform_pool[pools.fused];
+                    pools.fused += 1;
+                    gpu::write_uniform(queue, buffer, &uniforms);
+                    let bg = gpu::standard_bind_group(
+                        device,
+                        &self.combined.bgl,
+                        buffer,
+                        prev,
+                        &self.trilinear_sampler,
+                        Some("passthrough-bg"),
+                    );
+                    self.combined.run(encoder, &bg, out);
+                }
+            },
+        }
+    }
+
+    fn step_input_view(&self, ti: usize, prev_in_a: bool) -> &TextureView {
+        if prev_in_a {
+            &self.bank_a[ti].as_ref().unwrap().view
+        } else {
+            &self.bank_b[ti].as_ref().unwrap().view
+        }
+    }
+
+    fn step_output_view(&self, ti: usize, last: bool, prev_in_a: bool) -> &TextureView {
+        if last {
+            &self.tile_outputs[ti].as_ref().unwrap().view
+        } else if prev_in_a {
+            &self.bank_b[ti].as_ref().unwrap().view
+        } else {
+            &self.bank_a[ti].as_ref().unwrap().view
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn sort_cross_tile(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        source: &TiledSource,
+        groups: &[Vec<usize>],
+        last: bool,
+        prev_in_a: bool,
+        vertical: bool,
+        threshold: f32,
+        angle: f32,
+        budgeted: bool,
+        scale: f32,
+    ) -> bool {
+        let budget = device.limits().max_buffer_size.min(PIXEL_SORT_BUF_BUDGET);
+        let line_len = if vertical {
+            scaled(source.full_height, scale)
+        } else {
+            scaled(source.full_width, scale)
+        };
+        let stile = |ti: usize| -> (u32, u32, u32, u32) {
+            let t = &source.tiles[ti];
+            let sx0 = scaled(t.x, scale);
+            let sy0 = scaled(t.y, scale);
+            (
+                sx0,
+                sy0,
+                (scaled(t.x + t.width, scale) - sx0).max(1),
+                (scaled(t.y + t.height, scale) - sy0).max(1),
+            )
+        };
+
+        let mut units: Vec<(usize, u32, u32)> = Vec::new();
+        for (gi, group) in groups.iter().enumerate() {
+            let (_, _, sw0, sh0) = stile(group[0]);
+            let cross = if vertical { sw0 } else { sh0 };
+            let per_line_bytes = if vertical {
+                (line_len as u64) * 4
+            } else {
+                ((line_len * 4).div_ceil(256) * 256) as u64
+            };
+            let mem_band = (budget / per_line_bytes.max(1)).max(1) as u32;
+            let band = mem_band.min(PIXEL_SORT_LINES_PER_BAND).min(cross).max(1);
+            let mut c0 = 0u32;
+            while c0 < cross {
+                let c1 = (c0 + band).min(cross);
+                units.push((gi, c0, c1));
+                c0 = c1;
+            }
+        }
+
+        let total = units.len() as u32;
+        let (start, end) = if budgeted {
+            let start = self.sort_band_cursor.min(total);
+            let end = (start + PIXEL_SORT_BANDS_PER_FRAME).min(total);
+            self.sort_band_cursor = end;
+            (start, end)
+        } else {
+            (0, total)
+        };
+
+        for &(gi, c0, c1) in &units[start as usize..end as usize] {
+            let group = &groups[gi];
+            {
+                let band_n = c1 - c0;
+
+                let (sort_w, sort_h) = if vertical {
+                    (band_n, line_len)
+                } else {
+                    (line_len, band_n)
+                };
+                let row_bytes = (sort_w * 4).div_ceil(256) * 256;
+                let row_words = row_bytes / 4;
+                let bytes = (row_bytes * sort_h) as u64;
+                let need_new = self
+                    .sort_buffers
+                    .as_ref()
+                    .is_none_or(|(s, _)| s.size() < bytes);
+                if need_new {
+                    self.sort_buffers = Some((
+                        gpu::storage_buffer(device, bytes, Some("pixel-sort-src")),
+                        gpu::storage_buffer(device, bytes, Some("pixel-sort-dst")),
+                    ));
+                }
+                if self.pixel_sort_uniform_pool.is_empty() {
+                    self.pixel_sort_uniform_pool
+                        .push(self.pixel_sort.uniform_buffer(device));
+                }
+
+                let mut enc =
+                    device.create_command_encoder(&iced::wgpu::CommandEncoderDescriptor {
+                        label: Some("pixel-sort-cross-tile"),
+                    });
+                let (src_buf, dst_buf) = self.sort_buffers.as_ref().unwrap();
+                let uniform = &self.pixel_sort_uniform_pool[0];
+
+                let copy_origin = if vertical {
+                    iced::wgpu::Origin3d { x: c0, y: 0, z: 0 }
+                } else {
+                    iced::wgpu::Origin3d { x: 0, y: c0, z: 0 }
+                };
+                let copy_extent = |sw: u32, sh: u32| {
+                    if vertical {
+                        iced::wgpu::Extent3d {
+                            width: band_n,
+                            height: sh,
+                            depth_or_array_layers: 1,
+                        }
+                    } else {
+                        iced::wgpu::Extent3d {
+                            width: sw,
+                            height: band_n,
+                            depth_or_array_layers: 1,
+                        }
+                    }
+                };
+                let tile_offset = |sx0: u32, sy0: u32| -> u64 {
+                    if vertical {
+                        (sy0 as u64) * (row_bytes as u64)
+                    } else {
+                        (sx0 as u64) * 4
+                    }
+                };
+                for &ti in group {
+                    let (sx0, sy0, sw, sh) = stile(ti);
+                    let tex = self.sort_in_tex(ti, prev_in_a);
+                    enc.copy_texture_to_buffer(
+                        tex_copy_info(tex, copy_origin),
+                        iced::wgpu::TexelCopyBufferInfo {
+                            buffer: src_buf,
+                            layout: iced::wgpu::TexelCopyBufferLayout {
+                                offset: tile_offset(sx0, sy0),
+                                bytes_per_row: Some(row_bytes),
+                                rows_per_image: Some(sort_h),
+                            },
+                        },
+                        copy_extent(sw, sh),
+                    );
+                }
+
+                self.pixel_sort.record(
+                    device, queue, &mut enc, uniform, src_buf, dst_buf, sort_w, sort_h, row_words,
+                    threshold, angle,
+                );
+
+                for &ti in group {
+                    let (sx0, sy0, sw, sh) = stile(ti);
+                    let tex = self.sort_out_tex(ti, last, prev_in_a);
+                    enc.copy_buffer_to_texture(
+                        iced::wgpu::TexelCopyBufferInfo {
+                            buffer: dst_buf,
+                            layout: iced::wgpu::TexelCopyBufferLayout {
+                                offset: tile_offset(sx0, sy0),
+                                bytes_per_row: Some(row_bytes),
+                                rows_per_image: Some(sort_h),
+                            },
+                        },
+                        tex_copy_info(tex, copy_origin),
+                        copy_extent(sw, sh),
+                    );
+                }
+
+                queue.submit([enc.finish()]);
+            }
+        }
+
+        end >= total
+    }
+
+    fn sort_in_tex(&self, ti: usize, prev_in_a: bool) -> &Texture {
+        if prev_in_a {
+            &self.bank_a[ti].as_ref().unwrap()._tex
+        } else {
+            &self.bank_b[ti].as_ref().unwrap()._tex
+        }
+    }
+
+    fn sort_out_tex(&self, ti: usize, last: bool, prev_in_a: bool) -> &Texture {
+        if last {
+            &self.tile_outputs[ti].as_ref().unwrap()._tex
+        } else if prev_in_a {
+            &self.bank_b[ti].as_ref().unwrap()._tex
+        } else {
+            &self.bank_a[ti].as_ref().unwrap()._tex
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn sort_target(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        ti: usize,
+        target: SortTarget,
+        w: u32,
+        h: u32,
+        threshold: f32,
+        angle: f32,
+    ) {
+        let row_bytes = (w * 4).div_ceil(256) * 256;
+        let row_words = row_bytes / 4;
+        let bytes = (row_bytes * h) as u64;
+
+        let need_new = self
+            .sort_buffers
+            .as_ref()
+            .is_none_or(|(s, _)| s.size() < bytes);
+        if need_new {
+            self.sort_buffers = Some((
+                gpu::storage_buffer(device, bytes, Some("pixel-sort-src")),
+                gpu::storage_buffer(device, bytes, Some("pixel-sort-dst")),
+            ));
+        }
+        let (src, dst) = self.sort_buffers.as_ref().unwrap();
+
+        let tex = match target {
+            SortTarget::ScratchA => &self.scratch_a.as_ref().unwrap()._tex,
+            SortTarget::ScratchB => &self.scratch_b.as_ref().unwrap()._tex,
+            SortTarget::Output => &self.tile_outputs[ti].as_ref().unwrap()._tex,
+        };
+        let mut enc = device.create_command_encoder(&iced::wgpu::CommandEncoderDescriptor {
+            label: Some("pixel-sort-bridge"),
+        });
+        let copy_layout = iced::wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(row_bytes),
+            rows_per_image: Some(h),
+        };
+        let extent = iced::wgpu::Extent3d {
+            width: w,
+            height: h,
+            depth_or_array_layers: 1,
+        };
+        enc.copy_texture_to_buffer(
+            tex.as_image_copy(),
+            iced::wgpu::TexelCopyBufferInfo {
+                buffer: src,
+                layout: copy_layout,
+            },
+            extent,
+        );
+        if self.pixel_sort_uniform_pool.is_empty() {
+            self.pixel_sort_uniform_pool
+                .push(self.pixel_sort.uniform_buffer(device));
+        }
+        let uniform = &self.pixel_sort_uniform_pool[0];
+        self.pixel_sort.record(
+            device, queue, &mut enc, uniform, src, dst, w, h, row_words, threshold, angle,
+        );
+        enc.copy_buffer_to_texture(
+            iced::wgpu::TexelCopyBufferInfo {
+                buffer: dst,
+                layout: copy_layout,
+            },
+            tex.as_image_copy(),
+            extent,
+        );
+        queue.submit([enc.finish()]);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_separable_step(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        encoder: &mut CommandEncoder,
+        source: &TiledSource,
+        blur_set: &[usize],
+        proc_rects: &[Option<ProcRect>],
+        roi_active: bool,
+        radius: f32,
+        is_first: bool,
+        prev_in_a: bool,
+        last: bool,
+        blur_pool_used: &mut usize,
+    ) -> bool {
+        let full_w = source.full_width as f32;
+        let full_h = source.full_height as f32;
+
+        let bank_rect = |i: usize| -> Option<TileRect> {
+            proc_rects[i].as_ref().map(|p| TileRect {
+                origin: p.proc.origin,
+                size: p.proc.size,
+            })
+        };
+
+        if roi_active && last && is_first {
+            let mut deferred = false;
+            for &ti in blur_set {
+                if self.blur_tile_banded(
+                    device,
+                    queue,
+                    encoder,
+                    source,
+                    proc_rects,
+                    ti,
+                    radius,
+                    full_w,
+                    full_h,
+                    blur_pool_used,
+                ) {
+                    deferred = true;
+                }
+            }
+            return deferred;
+        }
+
+        for &ti in blur_set {
+            let pr = proc_rects[ti].as_ref().unwrap();
+            let proc_img_w = (pr.px[2] - pr.px[0]).max(1.0);
+            let radius_px = radius * pr.w as f32 / proc_img_w;
+            let sigma = (radius_px / 3.0).max(0.5);
+            let step = proc_img_w / pr.w as f32;
+            let rect = bank_rect(ti).unwrap();
+            let src = if is_first {
+                TileRect {
+                    origin: pr.src.origin,
+                    size: pr.src.size,
+                }
+            } else {
+                rect
+            };
+            let nb = if roi_active {
+                Neighbors::default()
+            } else {
+                tile_neighbors(&source.tiles, ti)
+            };
+
+            while self.blur_uniform_pool.len() < *blur_pool_used + 1 {
+                self.blur_uniform_pool
+                    .push(self.gaussian_blur.uniform_buffer(device));
+            }
+            let h_buffer = &self.blur_uniform_pool[*blur_pool_used];
+            *blur_pool_used += 1;
+
+            let p_view = |i: usize| -> Option<&TextureView> {
+                if is_first {
+                    Some(&source.tiles[i].source_view)
+                } else if prev_in_a {
+                    self.bank_a[i].as_ref().map(|t| &t.view)
+                } else {
+                    self.bank_b[i].as_ref().map(|t| &t.view)
+                }
+            };
+            let nbr_rect = |i: usize| -> Option<TileRect> {
+                if is_first {
+                    Some(full_rect(&TileInfo {
+                        tile_x: source.tiles[i].x,
+                        tile_y: source.tiles[i].y,
+                        tile_w: source.tiles[i].width,
+                        tile_h: source.tiles[i].height,
+                        full_w: source.full_width,
+                        full_h: source.full_height,
+                    }))
+                } else {
+                    bank_rect(i)
+                }
+            };
+
+            let input = p_view(ti).unwrap();
+            let lo = nb.left.and_then(|i| Some((p_view(i)?, nbr_rect(i)?)));
+            let hi = nb.right.and_then(|i| Some((p_view(i)?, nbr_rect(i)?)));
+            let h_out = &self.blur_hmid[ti].as_ref().unwrap().view;
+
+            let h_lod = if is_first { step.max(1.0).log2() } else { 0.0 };
+            self.gaussian_blur.record(
+                device,
+                queue,
+                encoder,
+                h_buffer,
+                [step / full_w, 0.0],
+                radius_px,
+                sigma,
+                rect,
+                src,
+                lo,
+                hi,
+                input,
+                h_out,
+                None,
+                h_lod,
+            );
+        }
+
+        for &ti in blur_set {
+            let pr = proc_rects[ti].as_ref().unwrap();
+            let proc_img_h = (pr.px[3] - pr.px[1]).max(1.0);
+            let radius_px = radius * pr.h as f32 / proc_img_h;
+            let sigma = (radius_px / 3.0).max(0.5);
+            let step = proc_img_h / pr.h as f32;
+            let rect = bank_rect(ti).unwrap();
+            let nb = if roi_active {
+                Neighbors::default()
+            } else {
+                tile_neighbors(&source.tiles, ti)
+            };
+
+            while self.blur_uniform_pool.len() < *blur_pool_used + 1 {
+                self.blur_uniform_pool
+                    .push(self.gaussian_blur.uniform_buffer(device));
+            }
+            let v_buffer = &self.blur_uniform_pool[*blur_pool_used];
+            *blur_pool_used += 1;
+
+            let h_view =
+                |i: usize| -> Option<&TextureView> { self.blur_hmid[i].as_ref().map(|t| &t.view) };
+
+            let input = h_view(ti).unwrap();
+            let lo = nb.up.and_then(|i| Some((h_view(i)?, bank_rect(i)?)));
+            let hi = nb.down.and_then(|i| Some((h_view(i)?, bank_rect(i)?)));
+
+            let v_out: &TextureView = if last {
+                &self.tile_outputs[ti].as_ref().unwrap().view
+            } else if prev_in_a {
+                &self.bank_b[ti].as_ref().unwrap().view
+            } else {
+                &self.bank_a[ti].as_ref().unwrap().view
+            };
+
+            self.gaussian_blur.record(
+                device,
+                queue,
+                encoder,
+                v_buffer,
+                [0.0, step / full_h],
+                radius_px,
+                sigma,
+                rect,
+                rect,
+                lo,
+                hi,
+                input,
+                v_out,
+                None,
+                0.0,
+            );
+        }
+        false
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn blur_tile_banded(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        encoder: &mut CommandEncoder,
+        source: &TiledSource,
+        proc_rects: &[Option<ProcRect>],
+        ti: usize,
+        radius: f32,
+        full_w: f32,
+        full_h: f32,
+        blur_pool_used: &mut usize,
+    ) -> bool {
+        let pr = proc_rects[ti].as_ref().unwrap();
+        let w = pr.w;
+        let h = pr.h;
+        let proc_img_w = (pr.px[2] - pr.px[0]).max(1.0);
+        let proc_img_h = (pr.px[3] - pr.px[1]).max(1.0);
+        let radius_h = radius * w as f32 / proc_img_w;
+        let radius_v = radius * h as f32 / proc_img_h;
+        let sigma_h = (radius_h / 3.0).max(0.5);
+        let sigma_v = (radius_v / 3.0).max(0.5);
+        let step_h = proc_img_w / w as f32;
+        let step_v = proc_img_h / h as f32;
+        let apron = radius_v.ceil() as u32;
+
+        let rect = TileRect {
+            origin: pr.proc.origin,
+            size: pr.proc.size,
+        };
+        let src = TileRect {
+            origin: pr.src.origin,
+            size: pr.src.size,
+        };
+
+        let tile_top = source.tiles[ti].y as f32;
+        let tile_bot = (source.tiles[ti].y + source.tiles[ti].height) as f32;
+        let apron_img = radius.ceil();
+        let nb = tile_neighbors(&source.tiles, ti);
+        let top_strip = match nb.up {
+            Some(up) if pr.px[1] <= tile_top + 0.5 => self.record_v_neighbor_strip(
+                device,
+                queue,
+                encoder,
+                source,
+                ti,
+                up,
+                pr,
+                apron,
+                apron_img,
+                w,
+                tile_top - apron_img,
+                tile_top,
+                full_w,
+                full_h,
+                step_h,
+                radius_h,
+                sigma_h,
+                blur_pool_used,
+                true,
+            ),
+            _ => None,
+        };
+        let bot_strip = match nb.down {
+            Some(down) if pr.px[3] >= tile_bot - 0.5 => self.record_v_neighbor_strip(
+                device,
+                queue,
+                encoder,
+                source,
+                ti,
+                down,
+                pr,
+                apron,
+                apron_img,
+                w,
+                tile_bot,
+                tile_bot + apron_img,
+                full_w,
+                full_h,
+                step_h,
+                radius_h,
+                sigma_h,
+                blur_pool_used,
+                false,
+            ),
+            _ => None,
+        };
+
+        let taps = 2 * (radius_h.ceil() as u32 + radius_v.ceil() as u32) + 2;
+        let per_row = (w.max(1)) * taps.max(1);
+        let band_h = (BLUR_WORK_BUDGET / per_row).clamp(BLUR_MIN_BAND_H, BLUR_MAX_BAND_H);
+
+        let start = self.tile_outputs[ti].as_ref().unwrap().band_y;
+        let mut by = start;
+        let mut bands_done = 0u32;
+        while by < h && bands_done < 1 {
+            let by1 = (by + band_h).min(h);
+            let h0 = by.saturating_sub(apron);
+            let h1 = (by1 + apron).min(h);
+            while self.blur_uniform_pool.len() < *blur_pool_used + 2 {
+                self.blur_uniform_pool
+                    .push(self.gaussian_blur.uniform_buffer(device));
+            }
+            let (h_pool, v_pool) = self.blur_uniform_pool.split_at(*blur_pool_used + 1);
+            let h_buffer = &h_pool[*blur_pool_used];
+            let v_buffer = &v_pool[0];
+            *blur_pool_used += 2;
+
+            let input = &source.tiles[ti].source_view;
+            let h_out = &self.blur_hmid[ti].as_ref().unwrap().view;
+            let h_lod = step_h.max(1.0).log2();
+            let nb = tile_neighbors(&source.tiles, ti);
+            let tile_rect = |i: usize| -> TileRect {
+                full_rect(&TileInfo {
+                    tile_x: source.tiles[i].x,
+                    tile_y: source.tiles[i].y,
+                    tile_w: source.tiles[i].width,
+                    tile_h: source.tiles[i].height,
+                    full_w: source.full_width,
+                    full_h: source.full_height,
+                })
+            };
+            let lo = nb
+                .left
+                .map(|i| (&source.tiles[i].source_view, tile_rect(i)));
+            let hi = nb
+                .right
+                .map(|i| (&source.tiles[i].source_view, tile_rect(i)));
+            self.gaussian_blur.record(
+                device,
+                queue,
+                encoder,
+                h_buffer,
+                [step_h / full_w, 0.0],
+                radius_h,
+                sigma_h,
+                rect,
+                src,
+                lo,
+                hi,
+                input,
+                h_out,
+                Some([0, h0, w, h1 - h0]),
+                h_lod,
+            );
+
+            let hmid = &self.blur_hmid[ti].as_ref().unwrap().view;
+            let out = &self.tile_outputs[ti].as_ref().unwrap().view;
+            let lo_v =
+                top_strip.and_then(|r| self.blur_vstrip_top[ti].as_ref().map(|s| (&s.view, r)));
+            let hi_v =
+                bot_strip.and_then(|r| self.blur_vstrip_bot[ti].as_ref().map(|s| (&s.view, r)));
+            self.gaussian_blur.record(
+                device,
+                queue,
+                encoder,
+                v_buffer,
+                [0.0, step_v / full_h],
+                radius_v,
+                sigma_v,
+                rect,
+                rect,
+                lo_v,
+                hi_v,
+                hmid,
+                out,
+                Some([0, by, w, by1 - by]),
+                0.0,
+            );
+
+            by = by1;
+            bands_done += 1;
+        }
+
+        let o = self.tile_outputs[ti].as_mut().unwrap();
+        o.band_y = by;
+        by < h
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn record_v_neighbor_strip(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        encoder: &mut CommandEncoder,
+        source: &TiledSource,
+        ti: usize,
+        nbr: usize,
+        pr: &ProcRect,
+        apron: u32,
+        apron_img: f32,
+        w: u32,
+        y0_img: f32,
+        y1_img: f32,
+        full_w: f32,
+        full_h: f32,
+        step_h: f32,
+        radius_h: f32,
+        sigma_h: f32,
+        blur_pool_used: &mut usize,
+        top: bool,
+    ) -> Option<TileRect> {
+        let strip_h = apron.max(1);
+        if y1_img <= y0_img + 0.5 || apron_img < 0.5 || w == 0 {
+            return None;
+        }
+
+        {
+            let slot = if top {
+                &mut self.blur_vstrip_top[ti]
+            } else {
+                &mut self.blur_vstrip_bot[ti]
+            };
+            if slot
+                .as_ref()
+                .is_none_or(|s| s.width != w || s.height != strip_h)
+            {
+                *slot = Some(ScratchTarget::new(device, self.format, w, strip_h));
+            }
+        }
+
+        let strip_rect = TileRect {
+            origin: [pr.proc.origin[0], y0_img / full_h],
+            size: [pr.proc.size[0], (y1_img - y0_img) / full_h],
+        };
+        let nsrc = full_rect(&TileInfo {
+            tile_x: source.tiles[nbr].x,
+            tile_y: source.tiles[nbr].y,
+            tile_w: source.tiles[nbr].width,
+            tile_h: source.tiles[nbr].height,
+            full_w: source.full_width,
+            full_h: source.full_height,
+        });
+
+        while self.blur_uniform_pool.len() < *blur_pool_used + 1 {
+            self.blur_uniform_pool
+                .push(self.gaussian_blur.uniform_buffer(device));
+        }
+        let h_buffer = &self.blur_uniform_pool[*blur_pool_used];
+        *blur_pool_used += 1;
+
+        let strip_view = if top {
+            &self.blur_vstrip_top[ti].as_ref().unwrap().view
+        } else {
+            &self.blur_vstrip_bot[ti].as_ref().unwrap().view
+        };
+        let input = &source.tiles[nbr].source_view;
+        let h_lod = step_h.max(1.0).log2();
+        self.gaussian_blur.record(
+            device,
+            queue,
+            encoder,
+            h_buffer,
+            [step_h / full_w, 0.0],
+            radius_h,
+            sigma_h,
+            strip_rect,
+            nsrc,
+            None,
+            None,
+            input,
+            strip_view,
+            None,
+            h_lod,
+        );
+        Some(strip_rect)
     }
 }

--- a/src/wgpu/modifier_pipeline.rs
+++ b/src/wgpu/modifier_pipeline.rs
@@ -122,6 +122,15 @@ enum SortTarget {
     Output,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct SortDiagKey {
+    w: u32,
+    h: u32,
+    row_words: u32,
+    dx: i32,
+    dy: i32,
+}
+
 const TILE_BUDGET: usize = 2;
 
 struct Scheduler {
@@ -212,7 +221,8 @@ struct Neighbors {
 }
 
 use crate::modifiers::gpu::UvRect;
-use crate::modifiers::pixel_sort::SortAxis;
+use crate::modifiers::pixel_sort::{SortAxis, SortMode};
+use crate::wgpu::passes::pixel_sort::build_diagonal_index;
 
 struct ProcRect {
     px: [f32; 4],
@@ -448,7 +458,9 @@ pub struct ModifierPipeline {
     blur_uniform_pool: Vec<iced::wgpu::Buffer>,
     text_uniform_pool: Vec<iced::wgpu::Buffer>,
     pixel_sort_uniform_pool: Vec<iced::wgpu::Buffer>,
+    pixel_sort_diag_uniform_pool: Vec<iced::wgpu::Buffer>,
     sort_buffers: Option<(iced::wgpu::Buffer, iced::wgpu::Buffer)>,
+    sort_diag_index: Option<(SortDiagKey, iced::wgpu::Buffer, iced::wgpu::Buffer, u32)>,
     sort_band_cursor: u32,
     sort_progress_sig: u64,
     text_layers: Vec<Option<TextLayer>>,
@@ -523,7 +535,9 @@ impl ModifierPipeline {
             blur_uniform_pool: Vec::new(),
             text_uniform_pool: Vec::new(),
             pixel_sort_uniform_pool: Vec::new(),
+            pixel_sort_diag_uniform_pool: Vec::new(),
             sort_buffers: None,
+            sort_diag_index: None,
             sort_band_cursor: 0,
             sort_progress_sig: 0,
             text_layers: Vec::new(),
@@ -2127,6 +2141,47 @@ impl ModifierPipeline {
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn ensure_diag_index(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        w: u32,
+        h: u32,
+        row_words: u32,
+        dx: i32,
+        dy: i32,
+    ) {
+        let key = SortDiagKey {
+            w,
+            h,
+            row_words,
+            dx,
+            dy,
+        };
+        if self
+            .sort_diag_index
+            .as_ref()
+            .is_some_and(|(k, ..)| *k == key)
+        {
+            return;
+        }
+        let di = build_diagonal_index(w, h, row_words, dx, dy);
+        let index = gpu::storage_buffer(
+            device,
+            (di.index.len().max(1) * 4) as u64,
+            Some("pixel-sort-diag-index"),
+        );
+        let offset = gpu::storage_buffer(
+            device,
+            (di.offset.len().max(1) * 4) as u64,
+            Some("pixel-sort-diag-offset"),
+        );
+        queue.write_buffer(&index, 0, bytemuck::cast_slice(&di.index));
+        queue.write_buffer(&offset, 0, bytemuck::cast_slice(&di.offset));
+        self.sort_diag_index = Some((key, index, offset, di.n_lines));
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn sort_target(
         &mut self,
         device: &Device,
@@ -2141,6 +2196,11 @@ impl ModifierPipeline {
         let row_bytes = (w * 4).div_ceil(256) * 256;
         let row_words = row_bytes / 4;
         let bytes = (row_bytes * h) as u64;
+
+        let mode = SortMode::from_angle(angle);
+        if let SortMode::Diagonal { dx, dy } = mode {
+            self.ensure_diag_index(device, queue, w, h, row_words, dx, dy);
+        }
 
         let need_new = self
             .sort_buffers
@@ -2180,14 +2240,29 @@ impl ModifierPipeline {
             },
             extent,
         );
-        if self.pixel_sort_uniform_pool.is_empty() {
-            self.pixel_sort_uniform_pool
-                .push(self.pixel_sort.uniform_buffer(device));
+        match mode {
+            SortMode::Diagonal { .. } => {
+                let (_, index, offset, n_lines) = self.sort_diag_index.as_ref().unwrap();
+                if self.pixel_sort_diag_uniform_pool.is_empty() {
+                    self.pixel_sort_diag_uniform_pool
+                        .push(self.pixel_sort.diag_uniform_buffer(device));
+                }
+                let uniform = &self.pixel_sort_diag_uniform_pool[0];
+                self.pixel_sort.record_diagonal(
+                    device, queue, &mut enc, uniform, src, dst, index, offset, *n_lines, threshold,
+                );
+            }
+            SortMode::Cardinal(_) => {
+                if self.pixel_sort_uniform_pool.is_empty() {
+                    self.pixel_sort_uniform_pool
+                        .push(self.pixel_sort.uniform_buffer(device));
+                }
+                let uniform = &self.pixel_sort_uniform_pool[0];
+                self.pixel_sort.record(
+                    device, queue, &mut enc, uniform, src, dst, w, h, row_words, threshold, angle,
+                );
+            }
         }
-        let uniform = &self.pixel_sort_uniform_pool[0];
-        self.pixel_sort.record(
-            device, queue, &mut enc, uniform, src, dst, w, h, row_words, threshold, angle,
-        );
         enc.copy_buffer_to_texture(
             iced::wgpu::TexelCopyBufferInfo {
                 buffer: dst,

--- a/src/wgpu/modifier_pipeline.rs
+++ b/src/wgpu/modifier_pipeline.rs
@@ -7,7 +7,7 @@ use iced::wgpu::{
 
 use crate::{
     modifiers::{
-        Axis, EffectClass, Modifier, ModifierKind,
+        Modifier, ModifierKind,
         gpu::{ModUniforms, TileInfo, build_segment_uniforms},
     },
     wgpu::{
@@ -122,15 +122,6 @@ enum SortTarget {
     Output,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-struct SortDiagKey {
-    w: u32,
-    h: u32,
-    row_words: u32,
-    dx: i32,
-    dy: i32,
-}
-
 const TILE_BUDGET: usize = 2;
 
 struct Scheduler {
@@ -222,7 +213,6 @@ struct Neighbors {
 
 use crate::modifiers::gpu::UvRect;
 use crate::modifiers::pixel_sort::{SortAxis, SortMode};
-use crate::wgpu::passes::pixel_sort::build_diagonal_index;
 
 struct ProcRect {
     px: [f32; 4],
@@ -460,7 +450,6 @@ pub struct ModifierPipeline {
     pixel_sort_uniform_pool: Vec<iced::wgpu::Buffer>,
     pixel_sort_diag_uniform_pool: Vec<iced::wgpu::Buffer>,
     sort_buffers: Option<(iced::wgpu::Buffer, iced::wgpu::Buffer)>,
-    sort_diag_index: Option<(SortDiagKey, iced::wgpu::Buffer, iced::wgpu::Buffer, u32)>,
     sort_band_cursor: u32,
     sort_progress_sig: u64,
     text_layers: Vec<Option<TextLayer>>,
@@ -537,7 +526,6 @@ impl ModifierPipeline {
             pixel_sort_uniform_pool: Vec::new(),
             pixel_sort_diag_uniform_pool: Vec::new(),
             sort_buffers: None,
-            sort_diag_index: None,
             sort_band_cursor: 0,
             sort_progress_sig: 0,
             text_layers: Vec::new(),
@@ -1496,7 +1484,23 @@ impl ModifierPipeline {
         self.bank_b.resize_with(n_tiles, || None);
         self.blur_hmid.resize_with(n_tiles, || None);
 
-        let scale = fit_process_scale(
+        let mut has_h = false;
+        let mut has_v = false;
+        let mut has_diag = false;
+        for p in plan {
+            if let PlanItem::Step(_, m) = p
+                && let ModifierKind::PixelSort(ps) = &m.kind
+                && m.kind.effect_class().is_compute_scanline()
+            {
+                match SortMode::from_angle(ps.angle) {
+                    SortMode::Cardinal(SortAxis::Horizontal { .. }) => has_h = true,
+                    SortMode::Cardinal(SortAxis::Vertical { .. }) => has_v = true,
+                    SortMode::Diagonal { .. } => has_diag = true,
+                }
+            }
+        }
+
+        let mut scale = fit_process_scale(
             source.full_width,
             source.full_height,
             1,
@@ -1504,6 +1508,18 @@ impl ModifierPipeline {
             process_vram_budget(device),
             proc_scale,
         );
+        if has_diag {
+            let max_bytes = device.limits().max_buffer_size;
+            while scale > 1.0 / 4096.0 {
+                let sw = scaled(source.full_width, scale).max(1) as u64;
+                let sh = scaled(source.full_height, scale).max(1) as u64;
+                if (sw * 4).div_ceil(256) * 256 * sh <= max_bytes {
+                    break;
+                }
+                scale *= 0.5;
+            }
+        }
+        let scale = scale;
         let stile = |ti: usize, source: &TiledSource| -> (u32, u32, u32, u32) {
             let t = &source.tiles[ti];
             let sx0 = scaled(t.x, scale);
@@ -1512,19 +1528,6 @@ impl ModifierPipeline {
             let sy1 = scaled(t.y + t.height, scale);
             (sx0, sy0, (sx1 - sx0).max(1), (sy1 - sy0).max(1))
         };
-
-        let mut has_h = false;
-        let mut has_v = false;
-        for p in plan {
-            if let PlanItem::Step(_, m) = p
-                && let EffectClass::ComputeScanline { axis } = m.kind.effect_class()
-            {
-                match axis {
-                    Axis::Vertical => has_v = true,
-                    Axis::Horizontal => has_h = true,
-                }
-            }
-        }
 
         let visible: Vec<usize> = (0..n_tiles)
             .filter(|&ti| !tile_ndc_culled(source.tiles[ti].last_ndc_rect))
@@ -1542,7 +1545,7 @@ impl ModifierPipeline {
             .iter()
             .any(|p| matches!(p, PlanItem::Step(_, m) if m.kind.effect_class().separable_apron().is_some()));
 
-        let mut in_set = vec![false; n_tiles];
+        let mut in_set = vec![has_diag; n_tiles];
         for &v in &visible {
             let (vx, vy) = (source.tiles[v].x, source.tiles[v].y);
             for (ti, slot) in in_set.iter_mut().enumerate() {
@@ -1792,24 +1795,42 @@ impl ModifierPipeline {
                 } else if let PlanItem::Step(_, m) = item
                     && let ModifierKind::PixelSort(ps) = &m.kind
                 {
-                    let step_vertical =
-                        matches!(SortAxis::from_angle(ps.angle), SortAxis::Vertical { .. });
-                    let groups = pixel_sort_groups(source, &proc_set, step_vertical);
                     queue.submit([encoder.finish()]);
                     let budgeted = Some(k) == last_sort_k;
-                    let done = self.sort_cross_tile(
-                        device,
-                        queue,
-                        source,
-                        &groups,
-                        last,
-                        prev_in_a,
-                        step_vertical,
-                        ps.threshold,
-                        ps.angle,
-                        budgeted,
-                        scale,
-                    );
+                    let done = match SortMode::from_angle(ps.angle) {
+                        SortMode::Diagonal { dx, dy } => {
+                            self.sort_diag_full(
+                                device,
+                                queue,
+                                source,
+                                &proc_set,
+                                last,
+                                prev_in_a,
+                                ps.threshold,
+                                dx,
+                                dy,
+                                scale,
+                            );
+                            true
+                        }
+                        SortMode::Cardinal(axis) => {
+                            let step_vertical = matches!(axis, SortAxis::Vertical { .. });
+                            let groups = pixel_sort_groups(source, &proc_set, step_vertical);
+                            self.sort_cross_tile(
+                                device,
+                                queue,
+                                source,
+                                &groups,
+                                last,
+                                prev_in_a,
+                                step_vertical,
+                                ps.threshold,
+                                ps.angle,
+                                budgeted,
+                                scale,
+                            )
+                        }
+                    };
                     if budgeted {
                         sort_complete = done;
                     }
@@ -2027,16 +2048,7 @@ impl ModifierPipeline {
                 let row_bytes = (sort_w * 4).div_ceil(256) * 256;
                 let row_words = row_bytes / 4;
                 let bytes = (row_bytes * sort_h) as u64;
-                let need_new = self
-                    .sort_buffers
-                    .as_ref()
-                    .is_none_or(|(s, _)| s.size() < bytes);
-                if need_new {
-                    self.sort_buffers = Some((
-                        gpu::storage_buffer(device, bytes, Some("pixel-sort-src")),
-                        gpu::storage_buffer(device, bytes, Some("pixel-sort-dst")),
-                    ));
-                }
+                self.ensure_sort_buffers(device, bytes);
                 if self.pixel_sort_uniform_pool.is_empty() {
                     self.pixel_sort_uniform_pool
                         .push(self.pixel_sort.uniform_buffer(device));
@@ -2141,44 +2153,117 @@ impl ModifierPipeline {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn ensure_diag_index(
+    fn sort_diag_full(
         &mut self,
         device: &Device,
         queue: &Queue,
-        w: u32,
-        h: u32,
-        row_words: u32,
+        source: &TiledSource,
+        proc_set: &[usize],
+        last: bool,
+        prev_in_a: bool,
+        threshold: f32,
         dx: i32,
         dy: i32,
+        scale: f32,
     ) {
-        let key = SortDiagKey {
-            w,
-            h,
-            row_words,
-            dx,
-            dy,
-        };
-        if self
-            .sort_diag_index
-            .as_ref()
-            .is_some_and(|(k, ..)| *k == key)
-        {
+        let full_sw = scaled(source.full_width, scale).max(1);
+        let full_sh = scaled(source.full_height, scale).max(1);
+        let row_bytes = (full_sw * 4).div_ceil(256) * 256;
+        let row_words = row_bytes / 4;
+        let bytes = row_bytes as u64 * full_sh as u64;
+        if bytes > device.limits().max_buffer_size {
             return;
         }
-        let di = build_diagonal_index(w, h, row_words, dx, dy);
-        let index = gpu::storage_buffer(
-            device,
-            (di.index.len().max(1) * 4) as u64,
-            Some("pixel-sort-diag-index"),
+        self.ensure_sort_buffers(device, bytes);
+        if self.pixel_sort_diag_uniform_pool.is_empty() {
+            self.pixel_sort_diag_uniform_pool
+                .push(self.pixel_sort.diag_uniform_buffer(device));
+        }
+
+        let stile = |ti: usize| -> (u32, u32, u32, u32) {
+            let t = &source.tiles[ti];
+            let sx0 = scaled(t.x, scale);
+            let sy0 = scaled(t.y, scale);
+            (
+                sx0,
+                sy0,
+                (scaled(t.x + t.width, scale) - sx0).max(1),
+                (scaled(t.y + t.height, scale) - sy0).max(1),
+            )
+        };
+        let tile_layout = |sx0: u32, sy0: u32, sh: u32| iced::wgpu::TexelCopyBufferLayout {
+            offset: sy0 as u64 * row_bytes as u64 + sx0 as u64 * 4,
+            bytes_per_row: Some(row_bytes),
+            rows_per_image: Some(sh),
+        };
+
+        let mut enc = device.create_command_encoder(&iced::wgpu::CommandEncoderDescriptor {
+            label: Some("pixel-sort-diag-full"),
+        });
+        let (src_buf, dst_buf) = self.sort_buffers.as_ref().unwrap();
+        let uniform = &self.pixel_sort_diag_uniform_pool[0];
+
+        for &ti in proc_set {
+            let (sx0, sy0, sw, sh) = stile(ti);
+            let tex = self.sort_in_tex(ti, prev_in_a);
+            enc.copy_texture_to_buffer(
+                tex_copy_info(tex, iced::wgpu::Origin3d::ZERO),
+                iced::wgpu::TexelCopyBufferInfo {
+                    buffer: src_buf,
+                    layout: tile_layout(sx0, sy0, sh),
+                },
+                iced::wgpu::Extent3d {
+                    width: sw,
+                    height: sh,
+                    depth_or_array_layers: 1,
+                },
+            );
+        }
+
+        self.pixel_sort.record_diagonal(
+            device, queue, &mut enc, uniform, src_buf, dst_buf, full_sw, full_sh, row_words,
+            threshold, dx, dy,
         );
-        let offset = gpu::storage_buffer(
-            device,
-            (di.offset.len().max(1) * 4) as u64,
-            Some("pixel-sort-diag-offset"),
-        );
-        queue.write_buffer(&index, 0, bytemuck::cast_slice(&di.index));
-        queue.write_buffer(&offset, 0, bytemuck::cast_slice(&di.offset));
-        self.sort_diag_index = Some((key, index, offset, di.n_lines));
+
+        for &ti in proc_set {
+            let (sx0, sy0, sw, sh) = stile(ti);
+            let tex = self.sort_out_tex(ti, last, prev_in_a);
+            enc.copy_buffer_to_texture(
+                iced::wgpu::TexelCopyBufferInfo {
+                    buffer: dst_buf,
+                    layout: tile_layout(sx0, sy0, sh),
+                },
+                tex_copy_info(tex, iced::wgpu::Origin3d::ZERO),
+                iced::wgpu::Extent3d {
+                    width: sw,
+                    height: sh,
+                    depth_or_array_layers: 1,
+                },
+            );
+        }
+
+        queue.submit([enc.finish()]);
+    }
+
+    fn ensure_sort_buffers(&mut self, device: &Device, bytes: u64) {
+        let need_new = self
+            .sort_buffers
+            .as_ref()
+            .is_none_or(|(s, _)| s.size() < bytes);
+        if need_new {
+            self.sort_buffers = Some((
+                gpu::storage_buffer(device, bytes, Some("pixel-sort-src")),
+                gpu::storage_buffer(device, bytes, Some("pixel-sort-dst")),
+            ));
+        }
+    }
+
+    fn target_tex(&self, ti: usize, target: SortTarget) -> &Texture {
+        match target {
+            SortTarget::ScratchA => &self.scratch_a.as_ref().unwrap()._tex,
+            SortTarget::ScratchB => &self.scratch_b.as_ref().unwrap()._tex,
+            SortTarget::Output => &self.tile_outputs[ti].as_ref().unwrap()._tex,
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -2193,32 +2278,46 @@ impl ModifierPipeline {
         threshold: f32,
         angle: f32,
     ) {
+        match SortMode::from_angle(angle) {
+            SortMode::Diagonal { dx, dy } => {
+                self.sort_target_diagonal(device, queue, ti, target, w, h, threshold, dx, dy);
+            }
+            SortMode::Cardinal(axis) => {
+                let vertical = matches!(axis, SortAxis::Vertical { .. });
+                self.sort_target_cardinal(
+                    device, queue, ti, target, w, h, threshold, angle, vertical,
+                );
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn sort_target_diagonal(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        ti: usize,
+        target: SortTarget,
+        w: u32,
+        h: u32,
+        threshold: f32,
+        dx: i32,
+        dy: i32,
+    ) {
         let row_bytes = (w * 4).div_ceil(256) * 256;
         let row_words = row_bytes / 4;
-        let bytes = (row_bytes * h) as u64;
-
-        let mode = SortMode::from_angle(angle);
-        if let SortMode::Diagonal { dx, dy } = mode {
-            self.ensure_diag_index(device, queue, w, h, row_words, dx, dy);
+        let bytes = row_bytes as u64 * h as u64;
+        if bytes > device.limits().max_buffer_size {
+            return;
         }
-
-        let need_new = self
-            .sort_buffers
-            .as_ref()
-            .is_none_or(|(s, _)| s.size() < bytes);
-        if need_new {
-            self.sort_buffers = Some((
-                gpu::storage_buffer(device, bytes, Some("pixel-sort-src")),
-                gpu::storage_buffer(device, bytes, Some("pixel-sort-dst")),
-            ));
+        self.ensure_sort_buffers(device, bytes);
+        if self.pixel_sort_diag_uniform_pool.is_empty() {
+            self.pixel_sort_diag_uniform_pool
+                .push(self.pixel_sort.diag_uniform_buffer(device));
         }
         let (src, dst) = self.sort_buffers.as_ref().unwrap();
-
-        let tex = match target {
-            SortTarget::ScratchA => &self.scratch_a.as_ref().unwrap()._tex,
-            SortTarget::ScratchB => &self.scratch_b.as_ref().unwrap()._tex,
-            SortTarget::Output => &self.tile_outputs[ti].as_ref().unwrap()._tex,
-        };
+        let uniform = &self.pixel_sort_diag_uniform_pool[0];
+        let tex = self.target_tex(ti, target);
         let mut enc = device.create_command_encoder(&iced::wgpu::CommandEncoderDescriptor {
             label: Some("pixel-sort-bridge"),
         });
@@ -2240,29 +2339,9 @@ impl ModifierPipeline {
             },
             extent,
         );
-        match mode {
-            SortMode::Diagonal { .. } => {
-                let (_, index, offset, n_lines) = self.sort_diag_index.as_ref().unwrap();
-                if self.pixel_sort_diag_uniform_pool.is_empty() {
-                    self.pixel_sort_diag_uniform_pool
-                        .push(self.pixel_sort.diag_uniform_buffer(device));
-                }
-                let uniform = &self.pixel_sort_diag_uniform_pool[0];
-                self.pixel_sort.record_diagonal(
-                    device, queue, &mut enc, uniform, src, dst, index, offset, *n_lines, threshold,
-                );
-            }
-            SortMode::Cardinal(_) => {
-                if self.pixel_sort_uniform_pool.is_empty() {
-                    self.pixel_sort_uniform_pool
-                        .push(self.pixel_sort.uniform_buffer(device));
-                }
-                let uniform = &self.pixel_sort_uniform_pool[0];
-                self.pixel_sort.record(
-                    device, queue, &mut enc, uniform, src, dst, w, h, row_words, threshold, angle,
-                );
-            }
-        }
+        self.pixel_sort.record_diagonal(
+            device, queue, &mut enc, uniform, src, dst, w, h, row_words, threshold, dx, dy,
+        );
         enc.copy_buffer_to_texture(
             iced::wgpu::TexelCopyBufferInfo {
                 buffer: dst,
@@ -2272,6 +2351,86 @@ impl ModifierPipeline {
             extent,
         );
         queue.submit([enc.finish()]);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn sort_target_cardinal(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        ti: usize,
+        target: SortTarget,
+        w: u32,
+        h: u32,
+        threshold: f32,
+        angle: f32,
+        vertical: bool,
+    ) {
+        let budget = device.limits().max_buffer_size.min(PIXEL_SORT_BUF_BUDGET);
+        let cross = if vertical { w } else { h };
+        let line_px = if vertical { h as u64 } else { w as u64 };
+        let band = (budget / (line_px * 4).max(1))
+            .saturating_sub(64)
+            .clamp(1, cross as u64) as u32;
+
+        let (max_sw, max_sh) = if vertical { (band, h) } else { (w, band) };
+        let max_bytes = (((max_sw * 4).div_ceil(256) * 256) as u64) * max_sh as u64;
+        self.ensure_sort_buffers(device, max_bytes);
+        if self.pixel_sort_uniform_pool.is_empty() {
+            self.pixel_sort_uniform_pool
+                .push(self.pixel_sort.uniform_buffer(device));
+        }
+
+        let mut c0 = 0u32;
+        while c0 < cross {
+            let c1 = (c0 + band).min(cross);
+            let band_n = c1 - c0;
+            let (sw, sh) = if vertical { (band_n, h) } else { (w, band_n) };
+            let row_bytes = (sw * 4).div_ceil(256) * 256;
+            let row_words = row_bytes / 4;
+            let origin = if vertical {
+                iced::wgpu::Origin3d { x: c0, y: 0, z: 0 }
+            } else {
+                iced::wgpu::Origin3d { x: 0, y: c0, z: 0 }
+            };
+            let copy_layout = iced::wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(row_bytes),
+                rows_per_image: Some(sh),
+            };
+            let extent = iced::wgpu::Extent3d {
+                width: sw,
+                height: sh,
+                depth_or_array_layers: 1,
+            };
+            let (src, dst) = self.sort_buffers.as_ref().unwrap();
+            let uniform = &self.pixel_sort_uniform_pool[0];
+            let tex = self.target_tex(ti, target);
+            let mut enc = device.create_command_encoder(&iced::wgpu::CommandEncoderDescriptor {
+                label: Some("pixel-sort-bridge"),
+            });
+            enc.copy_texture_to_buffer(
+                tex_copy_info(tex, origin),
+                iced::wgpu::TexelCopyBufferInfo {
+                    buffer: src,
+                    layout: copy_layout,
+                },
+                extent,
+            );
+            self.pixel_sort.record(
+                device, queue, &mut enc, uniform, src, dst, sw, sh, row_words, threshold, angle,
+            );
+            enc.copy_buffer_to_texture(
+                iced::wgpu::TexelCopyBufferInfo {
+                    buffer: dst,
+                    layout: copy_layout,
+                },
+                tex_copy_info(tex, origin),
+                extent,
+            );
+            queue.submit([enc.finish()]);
+            c0 = c1;
+        }
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/wgpu/modifier_pipeline.rs
+++ b/src/wgpu/modifier_pipeline.rs
@@ -7,7 +7,7 @@ use iced::wgpu::{
 
 use crate::{
     modifiers::{
-        Modifier, ModifierKind,
+        Axis, EffectClass, Modifier, ModifierKind,
         gpu::{ModUniforms, TileInfo, build_segment_uniforms},
     },
     wgpu::{
@@ -411,7 +411,7 @@ fn plan_modifiers(modifiers: &[Modifier]) -> Vec<PlanItem<'_>> {
         if !m.has_visible_effect() {
             continue;
         }
-        if !m.kind.input_request().is_pointwise() {
+        if !m.kind.effect_class().is_pointwise() {
             if !current.is_empty() {
                 plan.push(PlanItem::Fused(std::mem::take(&mut current)));
             }
@@ -643,9 +643,9 @@ impl ModifierPipeline {
         let plan_vec = plan_modifiers(modifiers);
         let has_blur = plan_vec
             .iter()
-            .any(|p| matches!(p, PlanItem::Step(_, m) if m.kind.input_request().neighborhood_radius().is_some()));
+            .any(|p| matches!(p, PlanItem::Step(_, m) if m.kind.effect_class().separable_apron().is_some()));
         let has_pixel_sort = plan_vec.iter().any(
-            |p| matches!(p, PlanItem::Step(_, m) if matches!(m.kind, ModifierKind::PixelSort(_))),
+            |p| matches!(p, PlanItem::Step(_, m) if m.kind.effect_class().is_compute_scanline()),
         );
 
         if n_tiles > 1 && (has_blur || has_pixel_sort) {
@@ -769,7 +769,7 @@ impl ModifierPipeline {
                 let plan = plan.get_or_insert_with(|| plan_modifiers(modifiers));
                 let n_items = plan.len();
                 let plan_has_blur = plan.iter().any(|p| {
-                    matches!(p, PlanItem::Step(_, m) if m.kind.input_request().neighborhood_radius().is_some())
+                    matches!(p, PlanItem::Step(_, m) if m.kind.effect_class().separable_apron().is_some())
                 });
                 if n_items > 1 || plan_has_blur {
                     self.ensure_scratch(device, eff_w, eff_h);
@@ -820,9 +820,9 @@ impl ModifierPipeline {
                             self.combined.run(enc, &bg, out);
                         }
                         PlanItem::Step(idx, m)
-                            if m.kind.input_request().neighborhood_radius().is_some() =>
+                            if m.kind.effect_class().separable_apron().is_some() =>
                         {
-                            let radius = m.kind.input_request().neighborhood_radius().unwrap();
+                            let radius = m.kind.effect_class().separable_apron().unwrap();
                             {
                                 while self.blur_uniform_pool.len() < blur_pool_used + 2 {
                                     self.blur_uniform_pool
@@ -1169,7 +1169,7 @@ impl ModifierPipeline {
         let mut apron_px: f32 = 0.0;
         for item in plan {
             if let PlanItem::Step(_, m) = item
-                && let Some(radius) = m.kind.input_request().neighborhood_radius()
+                && let Some(radius) = m.kind.effect_class().separable_apron()
             {
                 apron_px = apron_px.max(radius);
             }
@@ -1178,7 +1178,7 @@ impl ModifierPipeline {
         let blur_is_sole_step = plan.len() == 1
             && matches!(
                 plan.first(),
-                Some(PlanItem::Step(_, m)) if m.kind.input_request().neighborhood_radius().is_some()
+                Some(PlanItem::Step(_, m)) if m.kind.effect_class().separable_apron().is_some()
             );
 
         let roi_active = !downscale
@@ -1382,7 +1382,7 @@ impl ModifierPipeline {
 
         for (k, item) in plan.iter().enumerate() {
             let last = k == plan_steps - 1;
-            let is_blur = matches!(item, PlanItem::Step(_, m) if m.kind.input_request().neighborhood_radius().is_some());
+            let is_blur = matches!(item, PlanItem::Step(_, m) if m.kind.effect_class().separable_apron().is_some());
             if !is_blur {
                 for &ti in &blur_set {
                     let tile = &source.tiles[ti];
@@ -1432,7 +1432,7 @@ impl ModifierPipeline {
             }
 
             if let PlanItem::Step(_, m) = item
-                && let Some(radius) = m.kind.input_request().neighborhood_radius()
+                && let Some(radius) = m.kind.effect_class().separable_apron()
             {
                 let deferred = self.run_separable_step(
                     device,
@@ -1503,11 +1503,11 @@ impl ModifierPipeline {
         let mut has_v = false;
         for p in plan {
             if let PlanItem::Step(_, m) = p
-                && let ModifierKind::PixelSort(ps) = &m.kind
+                && let EffectClass::ComputeScanline { axis } = m.kind.effect_class()
             {
-                match SortAxis::from_angle(ps.angle) {
-                    SortAxis::Vertical { .. } => has_v = true,
-                    SortAxis::Horizontal { .. } => has_h = true,
+                match axis {
+                    Axis::Vertical => has_v = true,
+                    Axis::Horizontal => has_h = true,
                 }
             }
         }
@@ -1526,7 +1526,7 @@ impl ModifierPipeline {
 
         let plan_has_blur = plan
             .iter()
-            .any(|p| matches!(p, PlanItem::Step(_, m) if m.kind.input_request().neighborhood_radius().is_some()));
+            .any(|p| matches!(p, PlanItem::Step(_, m) if m.kind.effect_class().separable_apron().is_some()));
 
         let mut in_set = vec![false; n_tiles];
         for &v in &visible {
@@ -1642,7 +1642,7 @@ impl ModifierPipeline {
         }
 
         let last_sort_k = plan.iter().enumerate().rev().find_map(|(k, p)| {
-            matches!(p, PlanItem::Step(_, m) if matches!(m.kind, ModifierKind::PixelSort(_)))
+            matches!(p, PlanItem::Step(_, m) if m.kind.effect_class().is_compute_scanline())
                 .then_some(k)
         });
 
@@ -1708,9 +1708,9 @@ impl ModifierPipeline {
 
             for (k, item) in plan.iter().enumerate() {
                 let last = k == plan_steps - 1;
-                let is_sort = matches!(item, PlanItem::Step(_, m) if matches!(m.kind, ModifierKind::PixelSort(_)));
+                let is_sort = matches!(item, PlanItem::Step(_, m) if m.kind.effect_class().is_compute_scanline());
                 let blur_radius = match item {
-                    PlanItem::Step(_, m) => m.kind.input_request().neighborhood_radius(),
+                    PlanItem::Step(_, m) => m.kind.effect_class().separable_apron(),
                     _ => None,
                 };
 

--- a/src/wgpu/passes/chromatic_aberration.rs
+++ b/src/wgpu/passes/chromatic_aberration.rs
@@ -5,15 +5,17 @@ use iced::wgpu::{
     Sampler, ShaderStages, StoreOp, TextureFormat, TextureView,
 };
 
-use crate::{modifiers::gpu::TileInfo, wgpu::gpu};
+use crate::{modifiers::gpu::UvRect, wgpu::gpu};
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 struct CaUniforms {
     amount: f32,
-    tile_origin: [f32; 2],
-    tile_size: [f32; 2],
-    _pad: [f32; 3],
+    _pad0: f32,
+    proc_origin: [f32; 2],
+    proc_size: [f32; 2],
+    src_origin: [f32; 2],
+    src_size: [f32; 2],
 }
 
 pub struct ChromaticAberrationPass {
@@ -61,21 +63,19 @@ impl ChromaticAberrationPass {
         encoder: &mut CommandEncoder,
         uniform_buffer: &Buffer,
         amount: f32,
-        tile: &TileInfo,
+        full_w: f32,
+        proc: UvRect,
+        src: UvRect,
         input: &TextureView,
         output: &TextureView,
     ) {
         let uniforms = CaUniforms {
-            amount: amount / tile.full_w as f32,
-            tile_origin: [
-                tile.tile_x as f32 / tile.full_w as f32,
-                tile.tile_y as f32 / tile.full_h as f32,
-            ],
-            tile_size: [
-                tile.tile_w as f32 / tile.full_w as f32,
-                tile.tile_h as f32 / tile.full_h as f32,
-            ],
-            _pad: [0.0; 3],
+            amount: amount / full_w,
+            _pad0: 0.0,
+            proc_origin: proc.origin,
+            proc_size: proc.size,
+            src_origin: src.origin,
+            src_size: src.size,
         };
         gpu::write_uniform(queue, uniform_buffer, &uniforms);
         let bg = gpu::standard_bind_group(

--- a/src/wgpu/passes/gaussian_blur.rs
+++ b/src/wgpu/passes/gaussian_blur.rs
@@ -1,0 +1,419 @@
+use bytemuck::{Pod, Zeroable};
+use iced::wgpu::{
+    BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor,
+    BindGroupLayoutEntry, BindingResource, BindingType, BlendState, Buffer, BufferBindingType,
+    CommandEncoder, Device, LoadOp, Operations, PrimitiveTopology, Queue,
+    RenderPassColorAttachment, RenderPassDescriptor, RenderPipeline, Sampler, SamplerBindingType,
+    ShaderStages, StoreOp, TextureFormat, TextureSampleType, TextureView, TextureViewDimension,
+};
+
+use crate::wgpu::gpu;
+
+#[derive(Copy, Clone)]
+pub struct TileRect {
+    pub origin: [f32; 2],
+    pub size: [f32; 2],
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+struct BlurUniforms {
+    direction: [f32; 2],
+    radius: f32,
+    sigma: f32,
+    proc_origin: [f32; 2],
+    proc_size: [f32; 2],
+    src_origin: [f32; 2],
+    src_size: [f32; 2],
+    lo_origin: [f32; 2],
+    lo_size: [f32; 2],
+    hi_origin: [f32; 2],
+    hi_size: [f32; 2],
+    has_lo: f32,
+    has_hi: f32,
+    src_lod: f32,
+    _pad: f32,
+}
+
+pub struct GaussianBlurPass {
+    pipeline: RenderPipeline,
+    bgl: BindGroupLayout,
+    sampler: Sampler,
+}
+
+impl GaussianBlurPass {
+    pub fn new(device: &Device, format: TextureFormat) -> Self {
+        let bgl = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("gaussian-blur-bgl"),
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                texture_entry(1),
+                BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Sampler(SamplerBindingType::Filtering),
+                    count: None,
+                },
+                texture_entry(3),
+                texture_entry(4),
+            ],
+        });
+        let pipeline = gpu::fullscreen_pipeline(
+            device,
+            include_str!("../shaders/gaussian_blur.wgsl"),
+            Some("gaussian-blur-pipeline"),
+            PrimitiveTopology::TriangleStrip,
+            format,
+            BlendState::REPLACE,
+            &bgl,
+        );
+        let sampler = device.create_sampler(&iced::wgpu::SamplerDescriptor {
+            label: Some("gaussian-blur-sampler"),
+            address_mode_u: iced::wgpu::AddressMode::ClampToEdge,
+            address_mode_v: iced::wgpu::AddressMode::ClampToEdge,
+            mag_filter: iced::wgpu::FilterMode::Linear,
+            min_filter: iced::wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+        Self {
+            pipeline,
+            bgl,
+            sampler,
+        }
+    }
+
+    fn bind_group(
+        &self,
+        device: &Device,
+        uniform_buffer: &Buffer,
+        input: &TextureView,
+        lo: &TextureView,
+        hi: &TextureView,
+    ) -> BindGroup {
+        device.create_bind_group(&BindGroupDescriptor {
+            label: Some("gaussian-blur-bg"),
+            layout: &self.bgl,
+            entries: &[
+                BindGroupEntry {
+                    binding: 0,
+                    resource: uniform_buffer.as_entire_binding(),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: BindingResource::TextureView(input),
+                },
+                BindGroupEntry {
+                    binding: 2,
+                    resource: BindingResource::Sampler(&self.sampler),
+                },
+                BindGroupEntry {
+                    binding: 3,
+                    resource: BindingResource::TextureView(lo),
+                },
+                BindGroupEntry {
+                    binding: 4,
+                    resource: BindingResource::TextureView(hi),
+                },
+            ],
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn record(
+        &self,
+        device: &Device,
+        queue: &Queue,
+        encoder: &mut CommandEncoder,
+        uniform_buffer: &Buffer,
+        direction: [f32; 2],
+        radius: f32,
+        sigma: f32,
+        tile: TileRect,
+        src: TileRect,
+        lo: Option<(&TextureView, TileRect)>,
+        hi: Option<(&TextureView, TileRect)>,
+        input: &TextureView,
+        output: &TextureView,
+        band: Option<[u32; 4]>,
+        src_lod: f32,
+    ) {
+        let (lo_view, lo_rect) = lo.unzip();
+        let (hi_view, hi_rect) = hi.unzip();
+        let lo_rect = lo_rect.unwrap_or(tile);
+        let hi_rect = hi_rect.unwrap_or(tile);
+
+        let uniforms = BlurUniforms {
+            direction,
+            radius,
+            sigma,
+            proc_origin: tile.origin,
+            proc_size: tile.size,
+            src_origin: src.origin,
+            src_size: src.size,
+            lo_origin: lo_rect.origin,
+            lo_size: lo_rect.size,
+            hi_origin: hi_rect.origin,
+            hi_size: hi_rect.size,
+            has_lo: if lo_view.is_some() { 1.0 } else { 0.0 },
+            has_hi: if hi_view.is_some() { 1.0 } else { 0.0 },
+            src_lod,
+            _pad: 0.0,
+        };
+        gpu::write_uniform(queue, uniform_buffer, &uniforms);
+
+        let bg = self.bind_group(
+            device,
+            uniform_buffer,
+            input,
+            lo_view.unwrap_or(input),
+            hi_view.unwrap_or(input),
+        );
+
+        let load = match band {
+            Some(_) => LoadOp::Load,
+            None => LoadOp::Clear(iced::wgpu::Color::TRANSPARENT),
+        };
+        let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some("gaussian-blur-pass"),
+            color_attachments: &[Some(RenderPassColorAttachment {
+                view: output,
+                resolve_target: None,
+                ops: Operations {
+                    load,
+                    store: StoreOp::Store,
+                },
+                depth_slice: None,
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &bg, &[]);
+        if let Some([x, y, w, h]) = band {
+            pass.set_scissor_rect(x, y, w, h);
+        }
+        pass.draw(0..4, 0..1);
+    }
+
+    pub fn uniform_buffer(&self, device: &Device) -> Buffer {
+        gpu::uniform_buffer::<BlurUniforms>(device, Some("gaussian-blur-uniform"))
+    }
+}
+
+fn texture_entry(binding: u32) -> BindGroupLayoutEntry {
+    BindGroupLayoutEntry {
+        binding,
+        visibility: ShaderStages::FRAGMENT,
+        ty: BindingType::Texture {
+            sample_type: TextureSampleType::Float { filterable: true },
+            view_dimension: TextureViewDimension::D2,
+            multisampled: false,
+        },
+        count: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wgpu::gpu;
+    use iced::wgpu::{
+        CommandEncoderDescriptor, DeviceDescriptor, Extent3d, Instance, PowerPreference,
+        RequestAdapterOptions, TexelCopyBufferInfo, TexelCopyBufferLayout, TextureUsages,
+    };
+
+    fn try_device() -> Option<(Device, Queue)> {
+        let instance = Instance::default();
+        let adapter =
+            futures::executor::block_on(instance.request_adapter(&RequestAdapterOptions {
+                power_preference: PowerPreference::default(),
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            }))
+            .ok()?;
+        futures::executor::block_on(adapter.request_device(&DeviceDescriptor::default())).ok()
+    }
+
+    fn rt(device: &Device, w: u32, h: u32, label: &str) -> iced::wgpu::Texture {
+        gpu::texture_2d(
+            device,
+            w,
+            h,
+            TextureFormat::Rgba8Unorm,
+            TextureUsages::RENDER_ATTACHMENT
+                | TextureUsages::TEXTURE_BINDING
+                | TextureUsages::COPY_SRC,
+            Some(label),
+        )
+    }
+
+    #[test]
+    fn banded_blur_matches_single_pass() {
+        let Some((device, queue)) = try_device() else {
+            eprintln!("banded_blur_matches_single_pass: no GPU adapter, skipping");
+            return;
+        };
+        let (w, h) = (64u32, 96u32);
+        let radius = 7.0f32;
+        let sigma = (radius / 3.0).max(0.5);
+
+        let src_tex = gpu::texture_2d(
+            &device,
+            w,
+            h,
+            TextureFormat::Rgba8Unorm,
+            TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
+            Some("src"),
+        );
+        let mut px = vec![0u8; (w * h * 4) as usize];
+        let mut s: u32 = 0xDEADBEEF;
+        for b in px.iter_mut() {
+            s = s.wrapping_mul(1664525).wrapping_add(1013904223);
+            *b = (s >> 24) as u8;
+        }
+        queue.write_texture(
+            src_tex.as_image_copy(),
+            &px,
+            TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(w * 4),
+                rows_per_image: Some(h),
+            },
+            Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+        let src_view = src_tex.create_view(&Default::default());
+
+        let pass = GaussianBlurPass::new(&device, TextureFormat::Rgba8Unorm);
+        let whole = TileRect {
+            origin: [0.0, 0.0],
+            size: [1.0, 1.0],
+        };
+        let dir_h = [1.0 / w as f32, 0.0];
+        let dir_v = [0.0, 1.0 / h as f32];
+
+        let hmid_a = rt(&device, w, h, "hmid_a");
+        let out_a = rt(&device, w, h, "out_a");
+        let (hv, vv) = (
+            hmid_a.create_view(&Default::default()),
+            out_a.create_view(&Default::default()),
+        );
+        let ub_h = pass.uniform_buffer(&device);
+        let ub_v = pass.uniform_buffer(&device);
+        let mut enc = device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+        pass.record(
+            &device, &queue, &mut enc, &ub_h, dir_h, radius, sigma, whole, whole, None, None,
+            &src_view, &hv, None, 0.0,
+        );
+        pass.record(
+            &device, &queue, &mut enc, &ub_v, dir_v, radius, sigma, whole, whole, None, None, &hv,
+            &vv, None, 0.0,
+        );
+        queue.submit([enc.finish()]);
+
+        let hmid_b = rt(&device, w, h, "hmid_b");
+        let out_b = rt(&device, w, h, "out_b");
+        let (hvb, vvb) = (
+            hmid_b.create_view(&Default::default()),
+            out_b.create_view(&Default::default()),
+        );
+        let apron = radius.ceil() as u32;
+        let band_h = 24u32;
+        let mut by = 0u32;
+        while by < h {
+            let by1 = (by + band_h).min(h);
+            let h0 = by.saturating_sub(apron);
+            let h1 = (by1 + apron).min(h);
+            let ubh = pass.uniform_buffer(&device);
+            let ubv = pass.uniform_buffer(&device);
+            let mut e = device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+            pass.record(
+                &device,
+                &queue,
+                &mut e,
+                &ubh,
+                dir_h,
+                radius,
+                sigma,
+                whole,
+                whole,
+                None,
+                None,
+                &src_view,
+                &hvb,
+                Some([0, h0, w, h1 - h0]),
+                0.0,
+            );
+            pass.record(
+                &device,
+                &queue,
+                &mut e,
+                &ubv,
+                dir_v,
+                radius,
+                sigma,
+                whole,
+                whole,
+                None,
+                None,
+                &hvb,
+                &vvb,
+                Some([0, by, w, by1 - by]),
+                0.0,
+            );
+            queue.submit([e.finish()]);
+            by = by1;
+        }
+
+        let read = |tex: &iced::wgpu::Texture| -> Vec<u8> {
+            let padded = (w * 4).div_ceil(256) * 256;
+            let buf = gpu::readback_buffer(&device, (padded * h) as u64, Some("rb"));
+            let mut e = device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+            e.copy_texture_to_buffer(
+                tex.as_image_copy(),
+                TexelCopyBufferInfo {
+                    buffer: &buf,
+                    layout: TexelCopyBufferLayout {
+                        offset: 0,
+                        bytes_per_row: Some(padded),
+                        rows_per_image: Some(h),
+                    },
+                },
+                Extent3d {
+                    width: w,
+                    height: h,
+                    depth_or_array_layers: 1,
+                },
+            );
+            queue.submit([e.finish()]);
+            let raw = gpu::read_buffer_blocking(&device, &buf);
+            let mut out = Vec::with_capacity((w * h * 4) as usize);
+            for row in 0..h {
+                let o = (row * padded) as usize;
+                out.extend_from_slice(&raw[o..o + (w * 4) as usize]);
+            }
+            out
+        };
+
+        let a = read(&out_a);
+        let b = read(&out_b);
+        let mismatches = a.iter().zip(&b).filter(|(x, y)| x != y).count();
+        assert_eq!(
+            mismatches, 0,
+            "banded blur != single-pass in {mismatches} bytes"
+        );
+    }
+}

--- a/src/wgpu/passes/mod.rs
+++ b/src/wgpu/passes/mod.rs
@@ -1,5 +1,7 @@
 pub mod checkerboard;
 pub mod chromatic_aberration;
 pub mod display;
+pub mod gaussian_blur;
 pub mod pixel_grid;
+pub mod pixel_sort;
 pub mod text;

--- a/src/wgpu/passes/pixel_sort.rs
+++ b/src/wgpu/passes/pixel_sort.rs
@@ -1,0 +1,520 @@
+use bytemuck::{Pod, Zeroable};
+use iced::wgpu::{
+    BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor,
+    BindGroupLayoutEntry, BindingType, Buffer, BufferBindingType, CommandEncoder,
+    ComputePassDescriptor, ComputePipeline, Device, Queue, ShaderStages,
+};
+
+use crate::modifiers::pixel_sort::{SortAxis, key_cutoff};
+use crate::wgpu::gpu;
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct PixelSortUniforms {
+    width: u32,
+    height: u32,
+    cutoff: u32,
+    reverse: u32,
+    vertical: u32,
+    row_words: u32,
+    _pad1: u32,
+    _pad2: u32,
+}
+
+pub struct PixelSortCompute {
+    pipeline: ComputePipeline,
+    bgl: BindGroupLayout,
+}
+
+impl PixelSortCompute {
+    pub fn new(device: &Device) -> Self {
+        let bgl = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("pixel-sort-bgl"),
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+        let pipeline = gpu::compute_pipeline(
+            device,
+            include_str!("../shaders/pixel_sort_compute.wgsl"),
+            "main",
+            Some("pixel-sort-pipeline"),
+            &bgl,
+        );
+        Self { pipeline, bgl }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn record(
+        &self,
+        device: &Device,
+        queue: &Queue,
+        encoder: &mut CommandEncoder,
+        uniform: &Buffer,
+        src: &Buffer,
+        dst: &Buffer,
+        width: u32,
+        height: u32,
+        row_words: u32,
+        threshold: f32,
+        angle: f32,
+    ) {
+        let axis = SortAxis::from_angle(angle);
+        let (vertical, reverse) = match axis {
+            SortAxis::Horizontal { reverse } => (0u32, reverse as u32),
+            SortAxis::Vertical { reverse } => (1u32, reverse as u32),
+        };
+        gpu::write_uniform(
+            queue,
+            uniform,
+            &PixelSortUniforms {
+                width,
+                height,
+                cutoff: key_cutoff(threshold) as u32,
+                reverse,
+                vertical,
+                row_words,
+                _pad1: 0,
+                _pad2: 0,
+            },
+        );
+        let n_lines = if vertical == 0 { height } else { width };
+        let bg = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("pixel-sort-bg"),
+            layout: &self.bgl,
+            entries: &[
+                BindGroupEntry {
+                    binding: 0,
+                    resource: uniform.as_entire_binding(),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: src.as_entire_binding(),
+                },
+                BindGroupEntry {
+                    binding: 2,
+                    resource: dst.as_entire_binding(),
+                },
+            ],
+        });
+        let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+            label: Some("pixel-sort-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &bg, &[]);
+        pass.dispatch_workgroups(n_lines.div_ceil(64), 1, 1);
+    }
+
+    pub fn uniform_buffer(&self, device: &Device) -> Buffer {
+        gpu::uniform_buffer::<PixelSortUniforms>(device, Some("pixel-sort-uniform"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modifiers::pixel_sort::pixel_sort_cpu;
+
+    use iced::wgpu::{
+        CommandEncoderDescriptor, DeviceDescriptor, Instance, PowerPreference,
+        RequestAdapterOptions,
+    };
+
+    fn try_device() -> Option<(Device, Queue)> {
+        let instance = Instance::default();
+        let adapter =
+            futures::executor::block_on(instance.request_adapter(&RequestAdapterOptions {
+                power_preference: PowerPreference::default(),
+                force_fallback_adapter: false,
+                compatible_surface: None,
+            }))
+            .ok()?;
+        futures::executor::block_on(adapter.request_device(&DeviceDescriptor::default())).ok()
+    }
+
+    fn pack(rgba: &[u8]) -> Vec<u32> {
+        rgba.chunks_exact(4)
+            .map(|p| {
+                (p[0] as u32) | ((p[1] as u32) << 8) | ((p[2] as u32) << 16) | ((p[3] as u32) << 24)
+            })
+            .collect()
+    }
+
+    fn unpack(words: &[u32]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(words.len() * 4);
+        for &w in words {
+            out.push((w & 0xff) as u8);
+            out.push(((w >> 8) & 0xff) as u8);
+            out.push(((w >> 16) & 0xff) as u8);
+            out.push(((w >> 24) & 0xff) as u8);
+        }
+        out
+    }
+
+    fn gpu_pixel_sort(
+        device: &Device,
+        queue: &Queue,
+        src: &[u8],
+        w: u32,
+        h: u32,
+        threshold: f32,
+        angle: f32,
+    ) -> Vec<u8> {
+        let words = pack(src);
+        let bytes = (words.len() * 4) as u64;
+        let src_buf = gpu::storage_buffer(device, bytes, Some("ps-src"));
+        let dst_buf = gpu::storage_buffer(device, bytes, Some("ps-dst"));
+        let read = gpu::readback_buffer(device, bytes, Some("ps-read"));
+        queue.write_buffer(&src_buf, 0, bytemuck::cast_slice(&words));
+
+        let pass = PixelSortCompute::new(device);
+        let uniform = pass.uniform_buffer(device);
+        let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+        pass.record(
+            device,
+            queue,
+            &mut encoder,
+            &uniform,
+            &src_buf,
+            &dst_buf,
+            w,
+            h,
+            w,
+            threshold,
+            angle,
+        );
+        encoder.copy_buffer_to_buffer(&dst_buf, 0, &read, 0, bytes);
+        queue.submit([encoder.finish()]);
+
+        let raw = gpu::read_buffer_blocking(device, &read);
+        let out_words: Vec<u32> = bytemuck::cast_slice(&raw).to_vec();
+        unpack(&out_words)
+    }
+
+    struct TestTile {
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+        tex: iced::wgpu::Texture,
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn cross_tile_sort(
+        device: &Device,
+        queue: &Queue,
+        tiles: &[TestTile],
+        full_w: u32,
+        full_h: u32,
+        vertical: bool,
+        threshold: f32,
+        angle: f32,
+        band: u32,
+    ) {
+        use std::collections::BTreeMap;
+        let pass = PixelSortCompute::new(device);
+        let uniform = pass.uniform_buffer(device);
+
+        let mut groups: BTreeMap<u32, Vec<usize>> = BTreeMap::new();
+        for (i, t) in tiles.iter().enumerate() {
+            let key = if vertical { t.x } else { t.y };
+            groups.entry(key).or_default().push(i);
+        }
+
+        for (_, group) in groups {
+            let cross = if vertical {
+                tiles[group[0]].w
+            } else {
+                tiles[group[0]].h
+            };
+            let band = band.clamp(1, cross);
+
+            let mut c0 = 0u32;
+            while c0 < cross {
+                let c1 = (c0 + band).min(cross);
+                let band_n = c1 - c0;
+                let (sort_w, sort_h) = if vertical {
+                    (band_n, full_h)
+                } else {
+                    (full_w, band_n)
+                };
+                let row_bytes = (sort_w * 4).div_ceil(256) * 256;
+                let row_words = row_bytes / 4;
+                let bytes = (row_bytes * sort_h) as u64;
+                let src_buf = gpu::storage_buffer(device, bytes, Some("ct-src"));
+                let dst_buf = gpu::storage_buffer(device, bytes, Some("ct-dst"));
+
+                let origin = if vertical {
+                    iced::wgpu::Origin3d { x: c0, y: 0, z: 0 }
+                } else {
+                    iced::wgpu::Origin3d { x: 0, y: c0, z: 0 }
+                };
+                let extent = |t: &TestTile| {
+                    if vertical {
+                        iced::wgpu::Extent3d {
+                            width: band_n,
+                            height: t.h,
+                            depth_or_array_layers: 1,
+                        }
+                    } else {
+                        iced::wgpu::Extent3d {
+                            width: t.w,
+                            height: band_n,
+                            depth_or_array_layers: 1,
+                        }
+                    }
+                };
+
+                let mut enc =
+                    device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+                for &i in &group {
+                    let t = &tiles[i];
+                    let offset = if vertical {
+                        (t.y as u64) * (row_bytes as u64)
+                    } else {
+                        (t.x as u64) * 4
+                    };
+                    enc.copy_texture_to_buffer(
+                        iced::wgpu::TexelCopyTextureInfo {
+                            texture: &t.tex,
+                            mip_level: 0,
+                            origin,
+                            aspect: iced::wgpu::TextureAspect::All,
+                        },
+                        iced::wgpu::TexelCopyBufferInfo {
+                            buffer: &src_buf,
+                            layout: iced::wgpu::TexelCopyBufferLayout {
+                                offset,
+                                bytes_per_row: Some(row_bytes),
+                                rows_per_image: Some(sort_h),
+                            },
+                        },
+                        extent(t),
+                    );
+                }
+                pass.record(
+                    device, queue, &mut enc, &uniform, &src_buf, &dst_buf, sort_w, sort_h,
+                    row_words, threshold, angle,
+                );
+                for &i in &group {
+                    let t = &tiles[i];
+                    let offset = if vertical {
+                        (t.y as u64) * (row_bytes as u64)
+                    } else {
+                        (t.x as u64) * 4
+                    };
+                    enc.copy_buffer_to_texture(
+                        iced::wgpu::TexelCopyBufferInfo {
+                            buffer: &dst_buf,
+                            layout: iced::wgpu::TexelCopyBufferLayout {
+                                offset,
+                                bytes_per_row: Some(row_bytes),
+                                rows_per_image: Some(sort_h),
+                            },
+                        },
+                        iced::wgpu::TexelCopyTextureInfo {
+                            texture: &t.tex,
+                            mip_level: 0,
+                            origin,
+                            aspect: iced::wgpu::TextureAspect::All,
+                        },
+                        extent(t),
+                    );
+                }
+                queue.submit([enc.finish()]);
+                c0 = c1;
+            }
+        }
+    }
+
+    fn read_tile(device: &Device, queue: &Queue, t: &TestTile) -> Vec<u8> {
+        let row_bytes = (t.w * 4).div_ceil(256) * 256;
+        let bytes = (row_bytes * t.h) as u64;
+        let read = gpu::readback_buffer(device, bytes, Some("tile-read"));
+        let mut enc = device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+        enc.copy_texture_to_buffer(
+            t.tex.as_image_copy(),
+            iced::wgpu::TexelCopyBufferInfo {
+                buffer: &read,
+                layout: iced::wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(row_bytes),
+                    rows_per_image: Some(t.h),
+                },
+            },
+            iced::wgpu::Extent3d {
+                width: t.w,
+                height: t.h,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit([enc.finish()]);
+        let raw = gpu::read_buffer_blocking(device, &read);
+        let mut out = Vec::with_capacity((t.w * t.h * 4) as usize);
+        for r in 0..t.h {
+            let start = (r * row_bytes) as usize;
+            out.extend_from_slice(&raw[start..start + (t.w * 4) as usize]);
+        }
+        out
+    }
+
+    #[test]
+    fn cross_tile_pixel_sort_matches_cpu_reference() {
+        let Some((device, queue)) = try_device() else {
+            eprintln!("cross_tile_pixel_sort_matches_cpu_reference: no GPU adapter, skipping");
+            return;
+        };
+
+        let (full_w, full_h) = (40u32, 24u32);
+        let (tw, th) = (16u32, 10u32);
+
+        let mut src = vec![0u8; (full_w * full_h * 4) as usize];
+        let mut s: u32 = 0x9e37_79b9;
+        for b in src.iter_mut() {
+            s = s.wrapping_mul(1664525).wrapping_add(1013904223);
+            *b = (s >> 24) as u8;
+        }
+        for p in src.chunks_exact_mut(4) {
+            p[3] = 255;
+        }
+
+        for &band in &[3u32, 7, 1000] {
+            for &(vertical, angle) in
+                &[(false, 0.0f32), (false, 180.0), (true, 90.0), (true, 270.0)]
+            {
+                for &threshold in &[0.0f32, 0.3, 0.6] {
+                    let mut tiles = Vec::new();
+                    let mut y = 0;
+                    while y < full_h {
+                        let h = th.min(full_h - y);
+                        let mut x = 0;
+                        while x < full_w {
+                            let w = tw.min(full_w - x);
+                            let tex = gpu::texture_2d(
+                                &device,
+                                w,
+                                h,
+                                iced::wgpu::TextureFormat::Rgba8Unorm,
+                                iced::wgpu::TextureUsages::COPY_SRC
+                                    | iced::wgpu::TextureUsages::COPY_DST,
+                                Some("test-tile"),
+                            );
+                            let rb = (w * 4).div_ceil(256) * 256;
+                            let mut padded = vec![0u8; (rb * h) as usize];
+                            for r in 0..h {
+                                for c in 0..w {
+                                    let si = (((y + r) * full_w + (x + c)) * 4) as usize;
+                                    let di = (r * rb + c * 4) as usize;
+                                    padded[di..di + 4].copy_from_slice(&src[si..si + 4]);
+                                }
+                            }
+                            queue.write_texture(
+                                tex.as_image_copy(),
+                                &padded,
+                                iced::wgpu::TexelCopyBufferLayout {
+                                    offset: 0,
+                                    bytes_per_row: Some(rb),
+                                    rows_per_image: Some(h),
+                                },
+                                iced::wgpu::Extent3d {
+                                    width: w,
+                                    height: h,
+                                    depth_or_array_layers: 1,
+                                },
+                            );
+                            tiles.push(TestTile { x, y, w, h, tex });
+                            x += tw;
+                        }
+                        y += th;
+                    }
+
+                    cross_tile_sort(
+                        &device, &queue, &tiles, full_w, full_h, vertical, threshold, angle, band,
+                    );
+
+                    let mut assembled = vec![0u8; (full_w * full_h * 4) as usize];
+                    for t in &tiles {
+                        let data = read_tile(&device, &queue, t);
+                        for r in 0..t.h {
+                            for c in 0..t.w {
+                                let si = ((r * t.w + c) * 4) as usize;
+                                let di = (((t.y + r) * full_w + (t.x + c)) * 4) as usize;
+                                assembled[di..di + 4].copy_from_slice(&data[si..si + 4]);
+                            }
+                        }
+                    }
+
+                    let cpu =
+                        pixel_sort_cpu(&src, full_w as usize, full_h as usize, threshold, angle);
+                    let mism = cpu.iter().zip(&assembled).filter(|(a, b)| a != b).count();
+                    assert_eq!(
+                        mism, 0,
+                        "cross-tile != CPU at band={band} vertical={vertical} angle={angle} threshold={threshold}: {mism} bytes"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn gpu_pixel_sort_matches_cpu_reference() {
+        let Some((device, queue)) = try_device() else {
+            eprintln!("gpu_pixel_sort_matches_cpu_reference: no GPU adapter, skipping");
+            return;
+        };
+
+        let (w, h) = (53usize, 29usize);
+        let mut src = vec![0u8; w * h * 4];
+        let mut s: u32 = 0x1234_5678;
+        for b in src.iter_mut() {
+            s = s.wrapping_mul(1664525).wrapping_add(1013904223);
+            *b = (s >> 24) as u8;
+        }
+        for p in src.chunks_exact_mut(4) {
+            p[3] = 255;
+        }
+
+        for &angle in &[0.0f32, 90.0, 180.0, 270.0] {
+            for &threshold in &[0.0f32, 0.25, 0.5, 0.75] {
+                let cpu = pixel_sort_cpu(&src, w, h, threshold, angle);
+                let gpu =
+                    gpu_pixel_sort(&device, &queue, &src, w as u32, h as u32, threshold, angle);
+                let mismatches = cpu.iter().zip(&gpu).filter(|(a, b)| a != b).count();
+                assert_eq!(
+                    mismatches, 0,
+                    "GPU != CPU pixel sort at angle {angle} threshold {threshold}: {mismatches} bytes differ"
+                );
+            }
+        }
+    }
+}

--- a/src/wgpu/passes/pixel_sort.rs
+++ b/src/wgpu/passes/pixel_sort.rs
@@ -5,7 +5,7 @@ use iced::wgpu::{
     ComputePassDescriptor, ComputePipeline, Device, Queue, ShaderStages,
 };
 
-use crate::modifiers::pixel_sort::{SortAxis, key_cutoff};
+use crate::modifiers::pixel_sort::{SortAxis, diagonal_lines, key_cutoff};
 use crate::wgpu::gpu;
 
 #[repr(C)]
@@ -21,9 +21,53 @@ struct PixelSortUniforms {
     _pad2: u32,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct PixelSortDiagUniforms {
+    n_lines: u32,
+    cutoff: u32,
+    _pad0: u32,
+    _pad1: u32,
+}
+
+pub struct DiagonalIndex {
+    pub index: Vec<u32>,
+    pub offset: Vec<u32>,
+    pub n_lines: u32,
+}
+
+pub fn build_diagonal_index(
+    width: u32,
+    height: u32,
+    row_words: u32,
+    dx: i32,
+    dy: i32,
+) -> DiagonalIndex {
+    let lines = diagonal_lines(width as usize, height as usize, dx, dy);
+    let w = width as usize;
+    let mut index = Vec::with_capacity(w * height as usize);
+    let mut offset = Vec::with_capacity(lines.len() * 2);
+    for line in &lines {
+        offset.push(index.len() as u32);
+        offset.push(line.len() as u32);
+        for &tight in line {
+            let x = (tight % w) as u32;
+            let y = (tight / w) as u32;
+            index.push(y * row_words + x);
+        }
+    }
+    DiagonalIndex {
+        index,
+        offset,
+        n_lines: lines.len() as u32,
+    }
+}
+
 pub struct PixelSortCompute {
     pipeline: ComputePipeline,
     bgl: BindGroupLayout,
+    diag_pipeline: ComputePipeline,
+    diag_bgl: BindGroupLayout,
 }
 
 impl PixelSortCompute {
@@ -70,7 +114,50 @@ impl PixelSortCompute {
             Some("pixel-sort-pipeline"),
             &bgl,
         );
-        Self { pipeline, bgl }
+
+        let storage_entry = |binding: u32, read_only: bool| BindGroupLayoutEntry {
+            binding,
+            visibility: ShaderStages::COMPUTE,
+            ty: BindingType::Buffer {
+                ty: BufferBindingType::Storage { read_only },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
+        let diag_bgl = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("pixel-sort-diag-bgl"),
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                storage_entry(1, true),
+                storage_entry(2, false),
+                storage_entry(3, true),
+                storage_entry(4, true),
+            ],
+        });
+        let diag_pipeline = gpu::compute_pipeline(
+            device,
+            include_str!("../shaders/pixel_sort_diagonal.wgsl"),
+            "main",
+            Some("pixel-sort-diag-pipeline"),
+            &diag_bgl,
+        );
+
+        Self {
+            pipeline,
+            bgl,
+            diag_pipeline,
+            diag_bgl,
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -135,15 +222,78 @@ impl PixelSortCompute {
         pass.dispatch_workgroups(n_lines.div_ceil(64), 1, 1);
     }
 
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_diagonal(
+        &self,
+        device: &Device,
+        queue: &Queue,
+        encoder: &mut CommandEncoder,
+        uniform: &Buffer,
+        src: &Buffer,
+        dst: &Buffer,
+        index: &Buffer,
+        offset: &Buffer,
+        n_lines: u32,
+        threshold: f32,
+    ) {
+        gpu::write_uniform(
+            queue,
+            uniform,
+            &PixelSortDiagUniforms {
+                n_lines,
+                cutoff: key_cutoff(threshold) as u32,
+                _pad0: 0,
+                _pad1: 0,
+            },
+        );
+        let bg = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("pixel-sort-diag-bg"),
+            layout: &self.diag_bgl,
+            entries: &[
+                BindGroupEntry {
+                    binding: 0,
+                    resource: uniform.as_entire_binding(),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: src.as_entire_binding(),
+                },
+                BindGroupEntry {
+                    binding: 2,
+                    resource: dst.as_entire_binding(),
+                },
+                BindGroupEntry {
+                    binding: 3,
+                    resource: index.as_entire_binding(),
+                },
+                BindGroupEntry {
+                    binding: 4,
+                    resource: offset.as_entire_binding(),
+                },
+            ],
+        });
+        let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+            label: Some("pixel-sort-diag-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.diag_pipeline);
+        pass.set_bind_group(0, &bg, &[]);
+        pass.dispatch_workgroups(n_lines.div_ceil(64), 1, 1);
+    }
+
     pub fn uniform_buffer(&self, device: &Device) -> Buffer {
         gpu::uniform_buffer::<PixelSortUniforms>(device, Some("pixel-sort-uniform"))
+    }
+
+    pub fn diag_uniform_buffer(&self, device: &Device) -> Buffer {
+        gpu::uniform_buffer::<PixelSortDiagUniforms>(device, Some("pixel-sort-diag-uniform"))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::modifiers::pixel_sort::pixel_sort_cpu;
+    use crate::modifiers::pixel_sort::{SortMode, pixel_sort_cpu};
 
     use iced::wgpu::{
         CommandEncoderDescriptor, DeviceDescriptor, Instance, PowerPreference,
@@ -514,6 +664,108 @@ mod tests {
                     mismatches, 0,
                     "GPU != CPU pixel sort at angle {angle} threshold {threshold}: {mismatches} bytes differ"
                 );
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn gpu_pixel_sort_diagonal(
+        device: &Device,
+        queue: &Queue,
+        src: &[u8],
+        w: u32,
+        h: u32,
+        threshold: f32,
+        dx: i32,
+        dy: i32,
+        row_words: u32,
+    ) -> Vec<u8> {
+        let words = pack(src);
+        let rw = row_words as usize;
+        let mut padded = vec![0u32; rw * h as usize];
+        for y in 0..h as usize {
+            for x in 0..w as usize {
+                padded[y * rw + x] = words[y * w as usize + x];
+            }
+        }
+        let bytes = (padded.len() * 4) as u64;
+        let src_buf = gpu::storage_buffer(device, bytes, Some("psd-src"));
+        let dst_buf = gpu::storage_buffer(device, bytes, Some("psd-dst"));
+        let read = gpu::readback_buffer(device, bytes, Some("psd-read"));
+        queue.write_buffer(&src_buf, 0, bytemuck::cast_slice(&padded));
+
+        let di = build_diagonal_index(w, h, row_words, dx, dy);
+        let idx_buf = gpu::storage_buffer(device, (di.index.len() * 4) as u64, Some("psd-idx"));
+        let off_buf = gpu::storage_buffer(device, (di.offset.len() * 4) as u64, Some("psd-off"));
+        queue.write_buffer(&idx_buf, 0, bytemuck::cast_slice(&di.index));
+        queue.write_buffer(&off_buf, 0, bytemuck::cast_slice(&di.offset));
+
+        let pass = PixelSortCompute::new(device);
+        let uniform = pass.diag_uniform_buffer(device);
+        let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+        pass.record_diagonal(
+            device,
+            queue,
+            &mut encoder,
+            &uniform,
+            &src_buf,
+            &dst_buf,
+            &idx_buf,
+            &off_buf,
+            di.n_lines,
+            threshold,
+        );
+        encoder.copy_buffer_to_buffer(&dst_buf, 0, &read, 0, bytes);
+        queue.submit([encoder.finish()]);
+
+        let raw = gpu::read_buffer_blocking(device, &read);
+        let out_words: Vec<u32> = bytemuck::cast_slice(&raw).to_vec();
+        let mut tight = vec![0u32; w as usize * h as usize];
+        for y in 0..h as usize {
+            for x in 0..w as usize {
+                tight[y * w as usize + x] = out_words[y * rw + x];
+            }
+        }
+        unpack(&tight)
+    }
+
+    #[test]
+    fn gpu_diagonal_pixel_sort_matches_cpu_reference() {
+        let Some((device, queue)) = try_device() else {
+            eprintln!("gpu_diagonal_pixel_sort_matches_cpu_reference: no GPU adapter, skipping");
+            return;
+        };
+
+        let (w, h) = (53usize, 29usize);
+        let mut src = vec![0u8; w * h * 4];
+        let mut s: u32 = 0x1234_5678;
+        for b in src.iter_mut() {
+            s = s.wrapping_mul(1664525).wrapping_add(1013904223);
+            *b = (s >> 24) as u8;
+        }
+        for p in src.chunks_exact_mut(4) {
+            p[3] = 255;
+        }
+
+        let tight = w as u32;
+        let padded = (w as u32 * 4).div_ceil(256) * 256 / 4;
+        for &angle in &[45.0f32, 315.0, 26.565, 63.435, 71.565, 135.0] {
+            let (dx, dy) = match SortMode::from_angle(angle) {
+                SortMode::Diagonal { dx, dy } => (dx, dy),
+                other => panic!("angle {angle} did not map to a diagonal: {other:?}"),
+            };
+            for &threshold in &[0.0f32, 0.25, 0.5, 0.75] {
+                let cpu = pixel_sort_cpu(&src, w, h, threshold, angle);
+                for &row_words in &[tight, padded] {
+                    let gpu = gpu_pixel_sort_diagonal(
+                        &device, &queue, &src, w as u32, h as u32, threshold, dx, dy, row_words,
+                    );
+                    let mismatches = cpu.iter().zip(&gpu).filter(|(a, b)| a != b).count();
+                    assert_eq!(
+                        mismatches, 0,
+                        "GPU != CPU diagonal at angle {angle} ({dx},{dy}) threshold {threshold} row_words {row_words}: {mismatches} bytes"
+                    );
+                }
             }
         }
     }

--- a/src/wgpu/passes/pixel_sort.rs
+++ b/src/wgpu/passes/pixel_sort.rs
@@ -5,7 +5,7 @@ use iced::wgpu::{
     ComputePassDescriptor, ComputePipeline, Device, Queue, ShaderStages,
 };
 
-use crate::modifiers::pixel_sort::{SortAxis, diagonal_lines, key_cutoff};
+use crate::modifiers::pixel_sort::{SortAxis, key_cutoff, reduced_step};
 use crate::wgpu::gpu;
 
 #[repr(C)]
@@ -24,43 +24,18 @@ struct PixelSortUniforms {
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
 struct PixelSortDiagUniforms {
-    n_lines: u32,
-    cutoff: u32,
-    _pad0: u32,
-    _pad1: u32,
-}
-
-pub struct DiagonalIndex {
-    pub index: Vec<u32>,
-    pub offset: Vec<u32>,
-    pub n_lines: u32,
-}
-
-pub fn build_diagonal_index(
     width: u32,
     height: u32,
     row_words: u32,
-    dx: i32,
-    dy: i32,
-) -> DiagonalIndex {
-    let lines = diagonal_lines(width as usize, height as usize, dx, dy);
-    let w = width as usize;
-    let mut index = Vec::with_capacity(w * height as usize);
-    let mut offset = Vec::with_capacity(lines.len() * 2);
-    for line in &lines {
-        offset.push(index.len() as u32);
-        offset.push(line.len() as u32);
-        for &tight in line {
-            let x = (tight % w) as u32;
-            let y = (tight / w) as u32;
-            index.push(y * row_words + x);
-        }
-    }
-    DiagonalIndex {
-        index,
-        offset,
-        n_lines: lines.len() as u32,
-    }
+    cutoff: u32,
+    dx: u32,
+    dy: u32,
+    flip_x: u32,
+    flip_y: u32,
+    n_lines: u32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
 }
 
 pub struct PixelSortCompute {
@@ -140,8 +115,6 @@ impl PixelSortCompute {
                 },
                 storage_entry(1, true),
                 storage_entry(2, false),
-                storage_entry(3, true),
-                storage_entry(4, true),
             ],
         });
         let diag_pipeline = gpu::compute_pipeline(
@@ -231,19 +204,37 @@ impl PixelSortCompute {
         uniform: &Buffer,
         src: &Buffer,
         dst: &Buffer,
-        index: &Buffer,
-        offset: &Buffer,
-        n_lines: u32,
+        width: u32,
+        height: u32,
+        row_words: u32,
         threshold: f32,
+        dx: i32,
+        dy: i32,
     ) {
+        let (dx, dy) = reduced_step(dx, dy);
+        debug_assert!(dx != 0 && dy != 0, "diagonal sort requires nonzero steps");
+        if dx == 0 || dy == 0 || width == 0 || height == 0 {
+            return;
+        }
+        let bx = dx.unsigned_abs().min(width);
+        let by = dy.unsigned_abs().min(height);
+        let n_lines = bx * height + (width - bx) * by;
         gpu::write_uniform(
             queue,
             uniform,
             &PixelSortDiagUniforms {
-                n_lines,
+                width,
+                height,
+                row_words,
                 cutoff: key_cutoff(threshold) as u32,
+                dx: dx.unsigned_abs(),
+                dy: dy.unsigned_abs(),
+                flip_x: (dx < 0) as u32,
+                flip_y: (dy < 0) as u32,
+                n_lines,
                 _pad0: 0,
                 _pad1: 0,
+                _pad2: 0,
             },
         );
         let bg = device.create_bind_group(&BindGroupDescriptor {
@@ -261,14 +252,6 @@ impl PixelSortCompute {
                 BindGroupEntry {
                     binding: 2,
                     resource: dst.as_entire_binding(),
-                },
-                BindGroupEntry {
-                    binding: 3,
-                    resource: index.as_entire_binding(),
-                },
-                BindGroupEntry {
-                    binding: 4,
-                    resource: offset.as_entire_binding(),
                 },
             ],
         });
@@ -507,6 +490,82 @@ mod tests {
         }
     }
 
+    fn make_tiles(
+        device: &Device,
+        queue: &Queue,
+        src: &[u8],
+        full_w: u32,
+        full_h: u32,
+        tw: u32,
+        th: u32,
+    ) -> Vec<TestTile> {
+        let mut tiles = Vec::new();
+        let mut y = 0;
+        while y < full_h {
+            let h = th.min(full_h - y);
+            let mut x = 0;
+            while x < full_w {
+                let w = tw.min(full_w - x);
+                let tex = gpu::texture_2d(
+                    device,
+                    w,
+                    h,
+                    iced::wgpu::TextureFormat::Rgba8Unorm,
+                    iced::wgpu::TextureUsages::COPY_SRC | iced::wgpu::TextureUsages::COPY_DST,
+                    Some("test-tile"),
+                );
+                let rb = (w * 4).div_ceil(256) * 256;
+                let mut padded = vec![0u8; (rb * h) as usize];
+                for r in 0..h {
+                    for c in 0..w {
+                        let si = (((y + r) * full_w + (x + c)) * 4) as usize;
+                        let di = (r * rb + c * 4) as usize;
+                        padded[di..di + 4].copy_from_slice(&src[si..si + 4]);
+                    }
+                }
+                queue.write_texture(
+                    tex.as_image_copy(),
+                    &padded,
+                    iced::wgpu::TexelCopyBufferLayout {
+                        offset: 0,
+                        bytes_per_row: Some(rb),
+                        rows_per_image: Some(h),
+                    },
+                    iced::wgpu::Extent3d {
+                        width: w,
+                        height: h,
+                        depth_or_array_layers: 1,
+                    },
+                );
+                tiles.push(TestTile { x, y, w, h, tex });
+                x += tw;
+            }
+            y += th;
+        }
+        tiles
+    }
+
+    fn assemble_tiles(
+        device: &Device,
+        queue: &Queue,
+        tiles: &[TestTile],
+        full_w: u32,
+        full_h: u32,
+    ) -> Vec<u8> {
+        let mut assembled = vec![0u8; (full_w * full_h * 4) as usize];
+        for t in tiles {
+            let data = read_tile(device, queue, t);
+            for r in 0..t.h {
+                for c in 0..t.w {
+                    let si = ((r * t.w + c) * 4) as usize;
+                    let di = (((t.y + r) * full_w + (t.x + c)) * 4) as usize;
+                    assembled[di..di + 4].copy_from_slice(&data[si..si + 4]);
+                }
+            }
+        }
+        assembled
+    }
+
     fn read_tile(device: &Device, queue: &Queue, t: &TestTile) -> Vec<u8> {
         let row_bytes = (t.w * 4).div_ceil(256) * 256;
         let bytes = (row_bytes * t.h) as u64;
@@ -563,66 +622,13 @@ mod tests {
                 &[(false, 0.0f32), (false, 180.0), (true, 90.0), (true, 270.0)]
             {
                 for &threshold in &[0.0f32, 0.3, 0.6] {
-                    let mut tiles = Vec::new();
-                    let mut y = 0;
-                    while y < full_h {
-                        let h = th.min(full_h - y);
-                        let mut x = 0;
-                        while x < full_w {
-                            let w = tw.min(full_w - x);
-                            let tex = gpu::texture_2d(
-                                &device,
-                                w,
-                                h,
-                                iced::wgpu::TextureFormat::Rgba8Unorm,
-                                iced::wgpu::TextureUsages::COPY_SRC
-                                    | iced::wgpu::TextureUsages::COPY_DST,
-                                Some("test-tile"),
-                            );
-                            let rb = (w * 4).div_ceil(256) * 256;
-                            let mut padded = vec![0u8; (rb * h) as usize];
-                            for r in 0..h {
-                                for c in 0..w {
-                                    let si = (((y + r) * full_w + (x + c)) * 4) as usize;
-                                    let di = (r * rb + c * 4) as usize;
-                                    padded[di..di + 4].copy_from_slice(&src[si..si + 4]);
-                                }
-                            }
-                            queue.write_texture(
-                                tex.as_image_copy(),
-                                &padded,
-                                iced::wgpu::TexelCopyBufferLayout {
-                                    offset: 0,
-                                    bytes_per_row: Some(rb),
-                                    rows_per_image: Some(h),
-                                },
-                                iced::wgpu::Extent3d {
-                                    width: w,
-                                    height: h,
-                                    depth_or_array_layers: 1,
-                                },
-                            );
-                            tiles.push(TestTile { x, y, w, h, tex });
-                            x += tw;
-                        }
-                        y += th;
-                    }
+                    let tiles = make_tiles(&device, &queue, &src, full_w, full_h, tw, th);
 
                     cross_tile_sort(
                         &device, &queue, &tiles, full_w, full_h, vertical, threshold, angle, band,
                     );
 
-                    let mut assembled = vec![0u8; (full_w * full_h * 4) as usize];
-                    for t in &tiles {
-                        let data = read_tile(&device, &queue, t);
-                        for r in 0..t.h {
-                            for c in 0..t.w {
-                                let si = ((r * t.w + c) * 4) as usize;
-                                let di = (((t.y + r) * full_w + (t.x + c)) * 4) as usize;
-                                assembled[di..di + 4].copy_from_slice(&data[si..si + 4]);
-                            }
-                        }
-                    }
+                    let assembled = assemble_tiles(&device, &queue, &tiles, full_w, full_h);
 
                     let cpu =
                         pixel_sort_cpu(&src, full_w as usize, full_h as usize, threshold, angle);
@@ -694,12 +700,6 @@ mod tests {
         let read = gpu::readback_buffer(device, bytes, Some("psd-read"));
         queue.write_buffer(&src_buf, 0, bytemuck::cast_slice(&padded));
 
-        let di = build_diagonal_index(w, h, row_words, dx, dy);
-        let idx_buf = gpu::storage_buffer(device, (di.index.len() * 4) as u64, Some("psd-idx"));
-        let off_buf = gpu::storage_buffer(device, (di.offset.len() * 4) as u64, Some("psd-off"));
-        queue.write_buffer(&idx_buf, 0, bytemuck::cast_slice(&di.index));
-        queue.write_buffer(&off_buf, 0, bytemuck::cast_slice(&di.offset));
-
         let pass = PixelSortCompute::new(device);
         let uniform = pass.diag_uniform_buffer(device);
         let mut encoder = device.create_command_encoder(&CommandEncoderDescriptor { label: None });
@@ -710,10 +710,12 @@ mod tests {
             &uniform,
             &src_buf,
             &dst_buf,
-            &idx_buf,
-            &off_buf,
-            di.n_lines,
+            w,
+            h,
+            row_words,
             threshold,
+            dx,
+            dy,
         );
         encoder.copy_buffer_to_buffer(&dst_buf, 0, &read, 0, bytes);
         queue.submit([encoder.finish()]);
@@ -749,7 +751,9 @@ mod tests {
 
         let tight = w as u32;
         let padded = (w as u32 * 4).div_ceil(256) * 256 / 4;
-        for &angle in &[45.0f32, 315.0, 26.565, 63.435, 71.565, 135.0] {
+        for &angle in &[
+            45.0f32, 315.0, 26.565, 63.435, 71.565, 135.0, 206.565, 341.565,
+        ] {
             let (dx, dy) = match SortMode::from_angle(angle) {
                 SortMode::Diagonal { dx, dy } => (dx, dy),
                 other => panic!("angle {angle} did not map to a diagonal: {other:?}"),
@@ -766,6 +770,101 @@ mod tests {
                         "GPU != CPU diagonal at angle {angle} ({dx},{dy}) threshold {threshold} row_words {row_words}: {mismatches} bytes"
                     );
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn cross_tile_diagonal_pixel_sort_matches_cpu_reference() {
+        let Some((device, queue)) = try_device() else {
+            eprintln!(
+                "cross_tile_diagonal_pixel_sort_matches_cpu_reference: no GPU adapter, skipping"
+            );
+            return;
+        };
+
+        let (full_w, full_h) = (40u32, 24u32);
+        let (tw, th) = (16u32, 10u32);
+
+        let mut src = vec![0u8; (full_w * full_h * 4) as usize];
+        let mut s: u32 = 0x9e37_79b9;
+        for b in src.iter_mut() {
+            s = s.wrapping_mul(1664525).wrapping_add(1013904223);
+            *b = (s >> 24) as u8;
+        }
+        for p in src.chunks_exact_mut(4) {
+            p[3] = 255;
+        }
+
+        let pass = PixelSortCompute::new(&device);
+        let uniform = pass.diag_uniform_buffer(&device);
+        let row_bytes = (full_w * 4).div_ceil(256) * 256;
+        let row_words = row_bytes / 4;
+        let bytes = (row_bytes * full_h) as u64;
+
+        for &angle in &[45.0f32, 135.0, 315.0, 26.565] {
+            let (dx, dy) = match SortMode::from_angle(angle) {
+                SortMode::Diagonal { dx, dy } => (dx, dy),
+                other => panic!("angle {angle} did not map to a diagonal: {other:?}"),
+            };
+            for &threshold in &[0.0f32, 0.3, 0.6] {
+                let tiles = make_tiles(&device, &queue, &src, full_w, full_h, tw, th);
+                let src_buf = gpu::storage_buffer(&device, bytes, Some("ctd-src"));
+                let dst_buf = gpu::storage_buffer(&device, bytes, Some("ctd-dst"));
+
+                let mut enc =
+                    device.create_command_encoder(&CommandEncoderDescriptor { label: None });
+                for t in &tiles {
+                    let offset = (t.y as u64) * (row_bytes as u64) + (t.x as u64) * 4;
+                    enc.copy_texture_to_buffer(
+                        t.tex.as_image_copy(),
+                        iced::wgpu::TexelCopyBufferInfo {
+                            buffer: &src_buf,
+                            layout: iced::wgpu::TexelCopyBufferLayout {
+                                offset,
+                                bytes_per_row: Some(row_bytes),
+                                rows_per_image: Some(t.h),
+                            },
+                        },
+                        iced::wgpu::Extent3d {
+                            width: t.w,
+                            height: t.h,
+                            depth_or_array_layers: 1,
+                        },
+                    );
+                }
+                pass.record_diagonal(
+                    &device, &queue, &mut enc, &uniform, &src_buf, &dst_buf, full_w, full_h,
+                    row_words, threshold, dx, dy,
+                );
+                for t in &tiles {
+                    let offset = (t.y as u64) * (row_bytes as u64) + (t.x as u64) * 4;
+                    enc.copy_buffer_to_texture(
+                        iced::wgpu::TexelCopyBufferInfo {
+                            buffer: &dst_buf,
+                            layout: iced::wgpu::TexelCopyBufferLayout {
+                                offset,
+                                bytes_per_row: Some(row_bytes),
+                                rows_per_image: Some(t.h),
+                            },
+                        },
+                        t.tex.as_image_copy(),
+                        iced::wgpu::Extent3d {
+                            width: t.w,
+                            height: t.h,
+                            depth_or_array_layers: 1,
+                        },
+                    );
+                }
+                queue.submit([enc.finish()]);
+
+                let assembled = assemble_tiles(&device, &queue, &tiles, full_w, full_h);
+                let cpu = pixel_sort_cpu(&src, full_w as usize, full_h as usize, threshold, angle);
+                let mism = cpu.iter().zip(&assembled).filter(|(a, b)| a != b).count();
+                assert_eq!(
+                    mism, 0,
+                    "cross-tile diagonal != CPU at angle {angle} ({dx},{dy}) threshold {threshold}: {mism} bytes"
+                );
             }
         }
     }

--- a/src/wgpu/passes/text.rs
+++ b/src/wgpu/passes/text.rs
@@ -13,7 +13,11 @@ use iced::wgpu::{
 use std::borrow::Cow;
 
 use crate::{
-    modifiers::{gpu::TileInfo, kinds::Text, text_render},
+    modifiers::{
+        gpu::{TileInfo, UvRect},
+        kinds::Text,
+        text_render,
+    },
     wgpu::gpu,
 };
 
@@ -42,6 +46,10 @@ struct TextUniforms {
     px_range: f32,
     _pad0: f32,
     color: [f32; 4],
+    proc_origin: [f32; 2],
+    proc_size: [f32; 2],
+    src_origin: [f32; 2],
+    src_size: [f32; 2],
 }
 
 pub struct TextLayer {
@@ -346,6 +354,8 @@ impl TextPass {
         uniform_buffer: &Buffer,
         layer: &TextLayer,
         tile: &TileInfo,
+        proc: UvRect,
+        src: UvRect,
         input: &TextureView,
         output: &TextureView,
     ) {
@@ -378,18 +388,24 @@ impl TextPass {
             copy.draw(0..4, 0..1);
         }
 
+        let full_w = tile.full_w as f32;
+        let full_h = tile.full_h as f32;
         let uniforms = TextUniforms {
-            anchor: [layer.x * tile.full_w as f32, layer.y * tile.full_h as f32],
+            anchor: [layer.x * full_w, layer.y * full_h],
             block_size: [layer.block_w, layer.block_h],
             pivot: [0.5, 0.5],
-            tile_origin: [tile.tile_x as f32, tile.tile_y as f32],
-            tile_size: [tile.tile_w as f32, tile.tile_h as f32],
+            tile_origin: [proc.origin[0] * full_w, proc.origin[1] * full_h],
+            tile_size: [proc.size[0] * full_w, proc.size[1] * full_h],
             block_min: layer.block_min,
             rotation: layer.rotation.to_radians(),
             opacity: layer.opacity,
             px_range: PX_RANGE,
             _pad0: 0.0,
             color: [layer.color[0], layer.color[1], layer.color[2], 1.0],
+            proc_origin: proc.origin,
+            proc_size: proc.size,
+            src_origin: src.origin,
+            src_size: src.size,
         };
         gpu::write_uniform(queue, uniform_buffer, &uniforms);
 

--- a/src/wgpu/shaders/checkerboard.wgsl
+++ b/src/wgpu/shaders/checkerboard.wgsl
@@ -1,10 +1,10 @@
-struct Uniforms {
+struct CheckerboardUniforms {
     color_a: vec4<f32>,
     color_b: vec4<f32>,
     tile_size_pad: vec4<f32>,
 };
 
-@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(0) var<uniform> u: CheckerboardUniforms;
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
@@ -23,11 +23,11 @@ fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    let cell = vec2<i32>(floor(in.position.xy / uniforms.tile_size_pad.x));
+    let cell = vec2<i32>(floor(in.position.xy / u.tile_size_pad.x));
     let checker = (cell.x + cell.y) % 2;
     if checker == 0 {
-        return uniforms.color_a;
+        return u.color_a;
     } else {
-        return uniforms.color_b;
+        return u.color_b;
     }
 }

--- a/src/wgpu/shaders/chromatic_aberration.wgsl
+++ b/src/wgpu/shaders/chromatic_aberration.wgsl
@@ -1,12 +1,10 @@
 struct CaUniforms {
     amount: f32,
-    tile_origin_x: f32,
-    tile_origin_y: f32,
-    tile_size_x: f32,
-    tile_size_y: f32,
     _pad0: f32,
-    _pad1: f32,
-    _pad2: f32,
+    proc_origin: vec2<f32>,
+    proc_size: vec2<f32>,
+    src_origin: vec2<f32>,
+    src_size: vec2<f32>,
 }
 
 struct VertexOutput {
@@ -32,18 +30,17 @@ fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    let c = textureSample(t_image, s_image, in.uv);
+    let full_uv = u.proc_origin + in.uv * u.proc_size;
+    let src_uv = (full_uv - u.src_origin) / u.src_size;
+    let c = textureSample(t_image, s_image, src_uv);
 
-    let tile_origin = vec2<f32>(u.tile_origin_x, u.tile_origin_y);
-    let tile_size = vec2<f32>(u.tile_size_x, u.tile_size_y);
-    let full_uv = in.uv * tile_size + tile_origin;
     let offset = full_uv - vec2<f32>(0.5);
     let r_full = clamp(vec2<f32>(0.5) + offset * (1.0 + u.amount), vec2<f32>(0.0), vec2<f32>(1.0));
     let b_full = clamp(vec2<f32>(0.5) + offset * (1.0 - u.amount), vec2<f32>(0.0), vec2<f32>(1.0));
-    let r_tile = clamp((r_full - tile_origin) / tile_size, vec2<f32>(0.0), vec2<f32>(1.0));
-    let b_tile = clamp((b_full - tile_origin) / tile_size, vec2<f32>(0.0), vec2<f32>(1.0));
+    let r_src = clamp((r_full - u.src_origin) / u.src_size, vec2<f32>(0.0), vec2<f32>(1.0));
+    let b_src = clamp((b_full - u.src_origin) / u.src_size, vec2<f32>(0.0), vec2<f32>(1.0));
 
-    let cr = textureSample(t_image, s_image, r_tile);
-    let cb = textureSample(t_image, s_image, b_tile);
+    let cr = textureSample(t_image, s_image, r_src);
+    let cb = textureSample(t_image, s_image, b_src);
     return clamp(vec4<f32>(cr.r, c.g, cb.b, c.a), vec4<f32>(0.0), vec4<f32>(1.0));
 }

--- a/src/wgpu/shaders/combined_modifiers.wgsl
+++ b/src/wgpu/shaders/combined_modifiers.wgsl
@@ -7,6 +7,12 @@ struct ModUniforms {
     _pad0: u32,
     _pad1: u32,
     _pad2: u32,
+    proc_origin: vec2<f32>,
+    proc_size: vec2<f32>,
+    src_origin: vec2<f32>,
+    src_size: vec2<f32>,
+    full_size_px: vec2<f32>,
+    _pad3: vec2<f32>,
     entries: array<ModEntry, 32>,
 }
 
@@ -89,7 +95,7 @@ fn grain_value(cx: i32, cy: i32, wx: f32, wy: f32, seed: i32) -> f32 {
     return mix(mix(n00, n10, wx), mix(n01, n11, wx), wy);
 }
 
-fn apply_entry(e: ModEntry, tile_uv: vec2<f32>, c_in: vec4<f32>) -> vec4<f32> {
+fn apply_entry(e: ModEntry, full_uv: vec2<f32>, c_in: vec4<f32>) -> vec4<f32> {
     let kind = bitcast<u32>(e.data[0].x);
     let p0 = e.data[0].y;
     let p1 = e.data[0].z;
@@ -125,7 +131,6 @@ fn apply_entry(e: ModEntry, tile_uv: vec2<f32>, c_in: vec4<f32>) -> vec4<f32> {
             c = vec4<f32>(hsl_to_rgb(hsl), c.a);
         }
         case 5u: {
-            let full_uv = tile_uv * vec2<f32>(p5, p6) + vec2<f32>(p3, p4);
             let dist = length(full_uv - vec2<f32>(0.5, 0.5)) * 2.0;
             let inner = max(p1 - p2, 0.0);
             let vignette = 1.0 - smoothstep(inner, p1 + 0.0001, dist);
@@ -154,8 +159,8 @@ fn apply_entry(e: ModEntry, tile_uv: vec2<f32>, c_in: vec4<f32>) -> vec4<f32> {
             c = vec4<f32>(c.r + p0, c.g + p1, c.b + p2, c.a);
         }
         case 10u: {
-            let full_px_x = p3 + tile_uv.x * p5;
-            let full_px_y = p4 + tile_uv.y * p6;
+            let full_px_x = full_uv.x * u.full_size_px.x;
+            let full_px_y = full_uv.y * u.full_size_px.y;
             let iseed = i32(p2);
             let sz = max(p1, 0.5);
             let gx = full_px_x / sz;
@@ -183,7 +188,6 @@ fn apply_entry(e: ModEntry, tile_uv: vec2<f32>, c_in: vec4<f32>) -> vec4<f32> {
             c = vec4<f32>(c.rgb + grain, c.a);
         }
         case 16u: {
-            let full_uv = tile_uv * vec2<f32>(p4, p5) + vec2<f32>(p2, p3);
             let cs = cos(p1);
             let sn = sin(p1);
             let rot_uv = vec2<f32>(
@@ -206,10 +210,12 @@ fn apply_entry(e: ModEntry, tile_uv: vec2<f32>, c_in: vec4<f32>) -> vec4<f32> {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    var c = textureSample(t_image, s_image, in.uv);
+    let full_uv = u.proc_origin + in.uv * u.proc_size;
+    let src_uv = (full_uv - u.src_origin) / u.src_size;
+    var c = textureSample(t_image, s_image, src_uv);
 
     for (var i = 0u; i < u.count; i++) {
-        c = apply_entry(u.entries[i], in.uv, c);
+        c = apply_entry(u.entries[i], full_uv, c);
     }
 
     return clamp(c, vec4<f32>(0.0), vec4<f32>(1.0));

--- a/src/wgpu/shaders/display.wgsl
+++ b/src/wgpu/shaders/display.wgsl
@@ -1,4 +1,4 @@
-struct Uniforms {
+struct DisplayUniforms {
     transform: mat4x4<f32>,
     crop_uv: vec4<f32>,
 };
@@ -8,7 +8,7 @@ struct VertexOutput {
     @location(0) uv: vec2<f32>,
 };
 
-@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(0) var<uniform> u: DisplayUniforms;
 @group(0) @binding(1) var t_image: texture_2d<f32>;
 @group(0) @binding(2) var s_image: sampler;
 
@@ -19,7 +19,7 @@ fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
         vec2<f32>(-1.0,  1.0), vec2<f32>(1.0,  1.0)
     );
 
-    let clip_pos = (uniforms.transform * vec4<f32>(quad[vi], 0.0, 1.0)).xy;
+    let clip_pos = (u.transform * vec4<f32>(quad[vi], 0.0, 1.0)).xy;
 
     var out: VertexOutput;
     out.position = vec4<f32>(clip_pos, 0.0, 1.0);
@@ -29,6 +29,6 @@ fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    let uv = uniforms.crop_uv.xy + in.uv * (uniforms.crop_uv.zw - uniforms.crop_uv.xy);
+    let uv = u.crop_uv.xy + in.uv * (u.crop_uv.zw - u.crop_uv.xy);
     return textureSample(t_image, s_image, uv);
 }

--- a/src/wgpu/shaders/gaussian_blur.wgsl
+++ b/src/wgpu/shaders/gaussian_blur.wgsl
@@ -1,0 +1,80 @@
+struct BlurUniforms {
+    direction: vec2<f32>,
+    radius: f32,
+    sigma: f32,
+    proc_origin: vec2<f32>,
+    proc_size: vec2<f32>,
+    src_origin: vec2<f32>,
+    src_size: vec2<f32>,
+    lo_origin: vec2<f32>,
+    lo_size: vec2<f32>,
+    hi_origin: vec2<f32>,
+    hi_size: vec2<f32>,
+    has_lo: f32,
+    has_hi: f32,
+    src_lod: f32,
+    _pad: f32,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@group(0) @binding(0) var<uniform> u: BlurUniforms;
+@group(0) @binding(1) var t_image: texture_2d<f32>;
+@group(0) @binding(2) var s_image: sampler;
+@group(0) @binding(3) var t_lo: texture_2d<f32>;
+@group(0) @binding(4) var t_hi: texture_2d<f32>;
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
+    var quad = array<vec2<f32>, 4>(
+        vec2<f32>(-1.0, -1.0), vec2<f32>(1.0, -1.0),
+        vec2<f32>(-1.0,  1.0), vec2<f32>(1.0,  1.0)
+    );
+    var out: VertexOutput;
+    out.position = vec4<f32>(quad[vi], 0.0, 1.0);
+    out.uv = vec2<f32>((quad[vi].x + 1.0) * 0.5, 1.0 - (quad[vi].y + 1.0) * 0.5);
+    return out;
+}
+
+fn in_rect(full_uv: vec2<f32>, origin: vec2<f32>, size: vec2<f32>) -> bool {
+    let lo = origin;
+    let hi = origin + size;
+    return all(full_uv >= lo) && all(full_uv < hi);
+}
+
+fn sample_tap(full_uv: vec2<f32>) -> vec4<f32> {
+    if (u.has_lo > 0.5 && in_rect(full_uv, u.lo_origin, u.lo_size)) {
+        let local = (full_uv - u.lo_origin) / u.lo_size;
+        return textureSampleLevel(t_lo, s_image, local, 0.0);
+    }
+    if (u.has_hi > 0.5 && in_rect(full_uv, u.hi_origin, u.hi_size)) {
+        let local = (full_uv - u.hi_origin) / u.hi_size;
+        return textureSampleLevel(t_hi, s_image, local, 0.0);
+    }
+    let local = clamp((full_uv - u.src_origin) / u.src_size, vec2<f32>(0.0), vec2<f32>(1.0));
+    return textureSampleLevel(t_image, s_image, local, u.src_lod);
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    let r = i32(ceil(u.radius));
+    let full_uv = u.proc_origin + in.uv * u.proc_size;
+    if (r <= 0) {
+        let local = clamp((full_uv - u.src_origin) / u.src_size, vec2<f32>(0.0), vec2<f32>(1.0));
+        return textureSampleLevel(t_image, s_image, local, u.src_lod);
+    }
+    let inv_two_sigma_sq = 1.0 / (2.0 * u.sigma * u.sigma);
+    var sum = vec4<f32>(0.0);
+    var weight_sum = 0.0;
+    for (var i = -r; i <= r; i = i + 1) {
+        let fi = f32(i);
+        let w = exp(-fi * fi * inv_two_sigma_sq);
+        let tap_uv = full_uv + u.direction * fi;
+        sum = sum + sample_tap(tap_uv) * w;
+        weight_sum = weight_sum + w;
+    }
+    return sum / weight_sum;
+}

--- a/src/wgpu/shaders/pixel_grid.wgsl
+++ b/src/wgpu/shaders/pixel_grid.wgsl
@@ -1,10 +1,10 @@
-struct Uniforms {
+struct PixelGridUniforms {
     screen_to_img: mat4x4<f32>,
     viewport: vec4<f32>,
     bounds_img: vec4<f32>,
 };
 
-@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+@group(0) @binding(0) var<uniform> u: PixelGridUniforms;
 
 const GRID_STRENGTH: f32 = 0.5;
 
@@ -25,14 +25,14 @@ fn vs_main(@builtin(vertex_index) vi: u32) -> VertexOutput {
 
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
-    let vp = uniforms.viewport;
+    let vp = u.viewport;
     let ndc = vec2<f32>(
         (in.position.x - vp.x) / vp.z * 2.0 - 1.0,
         1.0 - (in.position.y - vp.y) / vp.w * 2.0,
     );
-    let img = (uniforms.screen_to_img * vec4<f32>(ndc, 0.0, 1.0)).xy;
+    let img = (u.screen_to_img * vec4<f32>(ndc, 0.0, 1.0)).xy;
 
-    let b = uniforms.bounds_img;
+    let b = u.bounds_img;
     if img.x < b.x || img.y < b.y || img.x > b.z || img.y > b.w {
         discard;
     }

--- a/src/wgpu/shaders/pixel_sort_compute.wgsl
+++ b/src/wgpu/shaders/pixel_sort_compute.wgsl
@@ -1,0 +1,86 @@
+struct PixelSortUniforms {
+    width: u32,
+    height: u32,
+    cutoff: u32,
+    reverse: u32,
+    vertical: u32,
+    row_words: u32,
+    _pad1: u32,
+    _pad2: u32,
+};
+
+@group(0) @binding(0) var<uniform> u: PixelSortUniforms;
+@group(0) @binding(1) var<storage, read> src: array<u32>;
+@group(0) @binding(2) var<storage, read_write> dst: array<u32>;
+
+fn luma(p: u32) -> u32 {
+    let r = f32(p & 0xffu);
+    let g = f32((p >> 8u) & 0xffu);
+    let b = f32((p >> 16u) & 0xffu);
+    let y = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    return u32(clamp(y + 0.5, 0.0, 255.0));
+}
+
+var<private> hist: array<u32, 256>;
+var<private> offset: array<u32, 256>;
+
+@compute @workgroup_size(64, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let line = gid.x;
+    let n = select(u.height, u.width, u.vertical == 0u);
+    let n_lines = select(u.width, u.height, u.vertical == 0u);
+    if (line >= n_lines) {
+        return;
+    }
+    var base: u32;
+    var stride: u32;
+    if (u.vertical == 0u) {
+        base = line * u.row_words;
+        stride = 1u;
+    } else {
+        base = line;
+        stride = u.row_words;
+    }
+
+    var i = 0u;
+    loop {
+        if (i >= n) { break; }
+        let cur = src[base + i * stride];
+        if (luma(cur) <= u.cutoff) {
+            dst[base + i * stride] = cur;
+            i = i + 1u;
+            continue;
+        }
+        let start = i;
+        var end = i;
+        loop {
+            if (end >= n) { break; }
+            if (luma(src[base + end * stride]) <= u.cutoff) { break; }
+            end = end + 1u;
+        }
+        let run_len = end - start;
+
+        for (var k = 0u; k < 256u; k = k + 1u) { hist[k] = 0u; }
+        for (var j = start; j < end; j = j + 1u) {
+            let key = luma(src[base + j * stride]);
+            hist[key] = hist[key] + 1u;
+        }
+        var acc = 0u;
+        for (var k = 0u; k < 256u; k = k + 1u) {
+            offset[k] = acc;
+            acc = acc + hist[k];
+        }
+        for (var j = start; j < end; j = j + 1u) {
+            let v = src[base + j * stride];
+            let key = luma(v);
+            let rank = offset[key];
+            offset[key] = rank + 1u;
+            var dst_rank = rank;
+            if (u.reverse != 0u) {
+                dst_rank = run_len - 1u - rank;
+            }
+            dst[base + (start + dst_rank) * stride] = v;
+        }
+        i = end;
+    }
+}

--- a/src/wgpu/shaders/pixel_sort_diagonal.wgsl
+++ b/src/wgpu/shaders/pixel_sort_diagonal.wgsl
@@ -1,15 +1,21 @@
 struct PixelSortDiagUniforms {
-    n_lines: u32,
+    width: u32,
+    height: u32,
+    row_words: u32,
     cutoff: u32,
+    dx: u32,
+    dy: u32,
+    flip_x: u32,
+    flip_y: u32,
+    n_lines: u32,
     _pad0: u32,
     _pad1: u32,
+    _pad2: u32,
 };
 
 @group(0) @binding(0) var<uniform> u: PixelSortDiagUniforms;
 @group(0) @binding(1) var<storage, read> src: array<u32>;
 @group(0) @binding(2) var<storage, read_write> dst: array<u32>;
-@group(0) @binding(3) var<storage, read> line_index: array<u32>;
-@group(0) @binding(4) var<storage, read> line_offset: array<u32>;
 
 fn luma(p: u32) -> u32 {
     let r = f32(p & 0xffu);
@@ -17,6 +23,20 @@ fn luma(p: u32) -> u32 {
     let b = f32((p >> 16u) & 0xffu);
     let y = 0.2126 * r + 0.7152 * g + 0.0722 * b;
     return u32(clamp(y + 0.5, 0.0, 255.0));
+}
+
+fn line_addr(x0: u32, y0: u32, i: u32) -> u32 {
+    let px = x0 + i * u.dx;
+    let py = y0 + i * u.dy;
+    var rx = px;
+    if (u.flip_x != 0u) {
+        rx = u.width - 1u - px;
+    }
+    var ry = py;
+    if (u.flip_y != 0u) {
+        ry = u.height - 1u - py;
+    }
+    return ry * u.row_words + rx;
 }
 
 var<private> hist: array<u32, 256>;
@@ -28,15 +48,29 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     if (line >= u.n_lines) {
         return;
     }
-    let base = line_offset[line * 2u];
-    let n = line_offset[line * 2u + 1u];
+    let bx = min(u.dx, u.width);
+    let left = bx * u.height;
+    var x0: u32;
+    var y0: u32;
+    if (line < left) {
+        x0 = line % bx;
+        y0 = line / bx;
+    } else {
+        let id2 = line - left;
+        let span = u.width - bx;
+        x0 = bx + id2 % span;
+        y0 = id2 / span;
+    }
+    let steps_x = (u.width - 1u - x0) / u.dx;
+    let steps_y = (u.height - 1u - y0) / u.dy;
+    let n = min(steps_x, steps_y) + 1u;
 
     var i = 0u;
     loop {
         if (i >= n) { break; }
-        let cur = src[line_index[base + i]];
+        let cur = src[line_addr(x0, y0, i)];
         if (luma(cur) <= u.cutoff) {
-            dst[line_index[base + i]] = cur;
+            dst[line_addr(x0, y0, i)] = cur;
             i = i + 1u;
             continue;
         }
@@ -44,13 +78,13 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
         var end = i;
         loop {
             if (end >= n) { break; }
-            if (luma(src[line_index[base + end]]) <= u.cutoff) { break; }
+            if (luma(src[line_addr(x0, y0, end)]) <= u.cutoff) { break; }
             end = end + 1u;
         }
 
         for (var k = 0u; k < 256u; k = k + 1u) { hist[k] = 0u; }
         for (var j = start; j < end; j = j + 1u) {
-            let key = luma(src[line_index[base + j]]);
+            let key = luma(src[line_addr(x0, y0, j)]);
             hist[key] = hist[key] + 1u;
         }
         var acc = 0u;
@@ -59,11 +93,11 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
             acc = acc + hist[k];
         }
         for (var j = start; j < end; j = j + 1u) {
-            let v = src[line_index[base + j]];
+            let v = src[line_addr(x0, y0, j)];
             let key = luma(v);
             let rank = offset[key];
             offset[key] = rank + 1u;
-            dst[line_index[base + start + rank]] = v;
+            dst[line_addr(x0, y0, start + rank)] = v;
         }
         i = end;
     }

--- a/src/wgpu/shaders/pixel_sort_diagonal.wgsl
+++ b/src/wgpu/shaders/pixel_sort_diagonal.wgsl
@@ -1,0 +1,70 @@
+struct PixelSortDiagUniforms {
+    n_lines: u32,
+    cutoff: u32,
+    _pad0: u32,
+    _pad1: u32,
+};
+
+@group(0) @binding(0) var<uniform> u: PixelSortDiagUniforms;
+@group(0) @binding(1) var<storage, read> src: array<u32>;
+@group(0) @binding(2) var<storage, read_write> dst: array<u32>;
+@group(0) @binding(3) var<storage, read> line_index: array<u32>;
+@group(0) @binding(4) var<storage, read> line_offset: array<u32>;
+
+fn luma(p: u32) -> u32 {
+    let r = f32(p & 0xffu);
+    let g = f32((p >> 8u) & 0xffu);
+    let b = f32((p >> 16u) & 0xffu);
+    let y = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    return u32(clamp(y + 0.5, 0.0, 255.0));
+}
+
+var<private> hist: array<u32, 256>;
+var<private> offset: array<u32, 256>;
+
+@compute @workgroup_size(64, 1, 1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let line = gid.x;
+    if (line >= u.n_lines) {
+        return;
+    }
+    let base = line_offset[line * 2u];
+    let n = line_offset[line * 2u + 1u];
+
+    var i = 0u;
+    loop {
+        if (i >= n) { break; }
+        let cur = src[line_index[base + i]];
+        if (luma(cur) <= u.cutoff) {
+            dst[line_index[base + i]] = cur;
+            i = i + 1u;
+            continue;
+        }
+        let start = i;
+        var end = i;
+        loop {
+            if (end >= n) { break; }
+            if (luma(src[line_index[base + end]]) <= u.cutoff) { break; }
+            end = end + 1u;
+        }
+
+        for (var k = 0u; k < 256u; k = k + 1u) { hist[k] = 0u; }
+        for (var j = start; j < end; j = j + 1u) {
+            let key = luma(src[line_index[base + j]]);
+            hist[key] = hist[key] + 1u;
+        }
+        var acc = 0u;
+        for (var k = 0u; k < 256u; k = k + 1u) {
+            offset[k] = acc;
+            acc = acc + hist[k];
+        }
+        for (var j = start; j < end; j = j + 1u) {
+            let v = src[line_index[base + j]];
+            let key = luma(v);
+            let rank = offset[key];
+            offset[key] = rank + 1u;
+            dst[line_index[base + start + rank]] = v;
+        }
+        i = end;
+    }
+}

--- a/src/wgpu/shaders/text_sdf.wgsl
+++ b/src/wgpu/shaders/text_sdf.wgsl
@@ -10,6 +10,10 @@ struct TextUniforms {
     px_range: f32,
     _pad0: f32,
     color: vec4<f32>,
+    proc_origin: vec2<f32>,
+    proc_size: vec2<f32>,
+    src_origin: vec2<f32>,
+    src_size: vec2<f32>,
 }
 
 struct Instance {
@@ -84,5 +88,7 @@ fn vs_copy(@builtin(vertex_index) vi: u32) -> CopyOut {
 
 @fragment
 fn fs_copy(in: CopyOut) -> @location(0) vec4<f32> {
-    return textureSample(t_atlas, s_atlas, in.uv);
+    let full_uv = u.proc_origin + in.uv * u.proc_size;
+    let src_uv = (full_uv - u.src_origin) / u.src_size;
+    return textureSample(t_atlas, s_atlas, src_uv);
 }

--- a/src/wgpu/tiled_source.rs
+++ b/src/wgpu/tiled_source.rs
@@ -9,7 +9,7 @@ use crate::wgpu::{
     gpu,
     media::image_data::{ImageData, ImageId},
     passes::display::DisplayPass,
-    view_pipeline::Uniforms,
+    view_pipeline::DisplayUniforms,
 };
 
 pub struct Tile {
@@ -22,6 +22,9 @@ pub struct Tile {
     pub last_ndc_rect: Option<(Vec2, Vec2)>,
     pub last_transform: Option<Mat4>,
     pub last_crop_uv: Option<[f32; 4]>,
+    pub proc_rect_uv: Option<[f32; 4]>,
+    pub proc_rect_px: Option<[f32; 4]>,
+    pub isec_px: Option<[f32; 4]>,
     pub x: u32,
     pub y: u32,
     pub width: u32,
@@ -182,9 +185,12 @@ impl TiledSource {
                     if mipmap_zoom_out {
                         TextureUsages::TEXTURE_BINDING
                             | TextureUsages::COPY_DST
+                            | TextureUsages::COPY_SRC
                             | TextureUsages::RENDER_ATTACHMENT
                     } else {
-                        TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST
+                        TextureUsages::TEXTURE_BINDING
+                            | TextureUsages::COPY_DST
+                            | TextureUsages::COPY_SRC
                     },
                     Some(&format!("{label}:source")),
                 );
@@ -215,7 +221,7 @@ impl TiledSource {
 
                 let source_view = source_texture.create_view(&Default::default());
 
-                let uniform_buffer = gpu::uniform_buffer::<Uniforms>(
+                let uniform_buffer = gpu::uniform_buffer::<DisplayUniforms>(
                     device,
                     Some(&format!("{label}:display-uniform")),
                 );
@@ -255,6 +261,9 @@ impl TiledSource {
                     last_ndc_rect: None,
                     last_transform: None,
                     last_crop_uv: None,
+                    proc_rect_uv: None,
+                    proc_rect_px: None,
+                    isec_px: None,
                     x: tx,
                     y: ty,
                     width: tw,

--- a/src/wgpu/view_pipeline.rs
+++ b/src/wgpu/view_pipeline.rs
@@ -29,7 +29,7 @@ use crate::{
 
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
 #[repr(C)]
-pub struct Uniforms {
+pub struct DisplayUniforms {
     pub transform: Mat4,
     pub crop_uv: [f32; 4],
 }
@@ -39,6 +39,30 @@ pub(crate) fn tile_ndc_culled(rect: Option<(Vec2, Vec2)>) -> bool {
         rect,
         Some((min, max)) if max.x < -1.0 || min.x > 1.0 || max.y < -1.0 || min.y > 1.0
     )
+}
+
+fn roi_from_ndc_clip((ndc_min, ndc_max): (Vec2, Vec2), rect: [f32; 4]) -> Option<[f32; 4]> {
+    let [left, top, right, bottom] = rect;
+    let nw = ndc_max.x - ndc_min.x;
+    let nh = ndc_max.y - ndc_min.y;
+    if nw <= 0.0 || nh <= 0.0 {
+        return None;
+    }
+    let fx0 = ((-1.0 - ndc_min.x) / nw).clamp(0.0, 1.0);
+    let fx1 = ((1.0 - ndc_min.x) / nw).clamp(0.0, 1.0);
+    let fy_from_top0 = ((ndc_max.y - 1.0) / nh).clamp(0.0, 1.0);
+    let fy_from_top1 = ((ndc_max.y + 1.0) / nh).clamp(0.0, 1.0);
+    if fx1 <= fx0 || fy_from_top1 <= fy_from_top0 {
+        return None;
+    }
+    let l = left + (right - left) * fx0;
+    let r = left + (right - left) * fx1;
+    let t = top + (bottom - top) * fy_from_top0;
+    let b = top + (bottom - top) * fy_from_top1;
+    if r - l < 1.0 || b - t < 1.0 {
+        return None;
+    }
+    Some([l, t, r, b])
 }
 
 fn ndc_rect_of_transform(transform: &Mat4) -> (Vec2, Vec2) {
@@ -71,8 +95,12 @@ pub struct ViewPipeline {
     scale_factor: f32,
     last_checker_uniforms: Option<CheckerboardUniforms>,
     pub mipmap_zoom_out: bool,
+    last_view: Option<DisplayUniforms>,
+    view_changed_at: std::time::Instant,
     format: TextureFormat,
 }
+
+const VIEW_SETTLE: std::time::Duration = std::time::Duration::from_millis(120);
 
 impl ViewPipeline {
     pub fn clear_source(&mut self, device: &Device) {
@@ -141,11 +169,16 @@ impl ViewPipeline {
         queue: &Queue,
         scale: f32,
         scale_factor: f32,
-        uniforms: &Uniforms,
+        uniforms: &DisplayUniforms,
         viewport: Vec2,
         pan_ndc: Vec2,
         rotation: u8,
     ) {
+        if self.last_view != Some(*uniforms) {
+            self.last_view = Some(*uniforms);
+            self.view_changed_at = std::time::Instant::now();
+        }
+
         self.scale_factor = scale_factor;
         let physical_scale = scale * scale_factor;
 
@@ -236,19 +269,33 @@ impl ViewPipeline {
                 * Mat4::from_translation(vec3(tile_offset.x, tile_offset.y, 0.0))
                 * Mat4::from_scale(vec3(tile_aspect.x, tile_aspect.y, 1.0));
 
-            if tile.last_transform != Some(transform) || tile.last_crop_uv != Some(uniforms.crop_uv)
+            let ndc = ndc_rect_of_transform(&transform);
+            let roi = if rotation == 0 {
+                roi_from_ndc_clip(ndc, [isec_left, isec_top, isec_right, isec_bottom])
+            } else {
+                None
+            };
+
+            if tile.last_transform != Some(transform)
+                || tile.last_crop_uv != Some(uniforms.crop_uv)
+                || tile.proc_rect_px != roi
             {
                 queue.write_buffer(
                     &tile.uniform_buffer,
                     0,
-                    bytes_of(&Uniforms {
+                    bytes_of(&DisplayUniforms {
                         transform,
                         crop_uv: per_tile_crop_uv,
                     }),
                 );
-                tile.last_ndc_rect = Some(ndc_rect_of_transform(&transform));
+                tile.last_ndc_rect = Some(ndc);
                 tile.last_transform = Some(transform);
                 tile.last_crop_uv = Some(uniforms.crop_uv);
+
+                tile.proc_rect_px = roi;
+                tile.proc_rect_uv =
+                    roi.map(|[l, t, r, b]| [l / full_w, t / full_h, r / full_w, b / full_h]);
+                tile.isec_px = roi.map(|_| [isec_left, isec_top, isec_right, isec_bottom]);
             }
         }
     }
@@ -262,6 +309,19 @@ impl ViewPipeline {
 
     pub fn update_pixel_grid(&self, queue: &Queue, uniforms: &PixelGridUniforms) {
         self.pixel_grid.update(queue, uniforms);
+    }
+
+    fn interacting(&self) -> bool {
+        self.view_changed_at.elapsed() < VIEW_SETTLE
+    }
+
+    pub fn reprocess_pending(&self) -> bool {
+        if self.interacting() {
+            return true;
+        }
+        self.modifier_pipeline
+            .as_ref()
+            .is_some_and(|mp| mp.reprocess_pending())
     }
 
     pub fn prepare_modifiers(
@@ -284,6 +344,17 @@ impl ViewPipeline {
 
         if !modifiers.iter().any(|m| m.has_visible_effect()) {
             self.modifier_pipeline = None;
+            return;
+        }
+
+        let has_expensive = modifiers
+            .iter()
+            .any(|m| m.has_visible_effect() && !m.kind.input_request().is_pointwise());
+        if has_expensive
+            && self.interacting()
+            && let Some(mp) = self.modifier_pipeline.as_mut()
+        {
+            mp.refresh_display_transforms(device, queue, source);
             return;
         }
 
@@ -337,7 +408,7 @@ impl ViewPipeline {
 
         if let Some(source) = &self.source {
             let zoomed_out = source.physical_scale < 1.0 - 1e-6;
-            if let Some(mp) = &self.modifier_pipeline {
+            if let Some(mp) = self.modifier_pipeline.as_ref() {
                 let nearest = !smooth_zoom_in && !zoomed_out;
                 for (i, tile) in source.tiles.iter().enumerate() {
                     if tile_ndc_culled(tile.last_ndc_rect) {
@@ -475,7 +546,7 @@ impl Pipeline for ViewPipeline {
         );
         let placeholder_view = placeholder_texture.create_view(&Default::default());
         let placeholder_uniform =
-            gpu::uniform_buffer::<Uniforms>(device, Some("placeholder-uniform"));
+            gpu::uniform_buffer::<DisplayUniforms>(device, Some("placeholder-uniform"));
         let placeholder_bind_group = display.create_bind_group(
             device,
             &placeholder_uniform,
@@ -504,6 +575,8 @@ impl Pipeline for ViewPipeline {
             pending_source_dirty: false,
             scale_factor: 1.0,
             last_checker_uniforms: None,
+            last_view: None,
+            view_changed_at: std::time::Instant::now() - VIEW_SETTLE * 2,
             format,
         }
     }

--- a/src/wgpu/view_pipeline.rs
+++ b/src/wgpu/view_pipeline.rs
@@ -349,7 +349,7 @@ impl ViewPipeline {
 
         let has_expensive = modifiers
             .iter()
-            .any(|m| m.has_visible_effect() && !m.kind.input_request().is_pointwise());
+            .any(|m| m.has_visible_effect() && !m.kind.effect_class().is_pointwise());
         if has_expensive
             && self.interacting()
             && let Some(mp) = self.modifier_pipeline.as_mut()

--- a/src/wgpu/view_primitive.rs
+++ b/src/wgpu/view_primitive.rs
@@ -13,13 +13,13 @@ use crate::{
     wgpu::{
         media::image_data::ImageData,
         passes::{checkerboard::CheckerboardUniforms, pixel_grid::PixelGridUniforms},
-        view_pipeline::{Uniforms, ViewPipeline},
+        view_pipeline::{DisplayUniforms, ViewPipeline},
     },
 };
 
 #[derive(Debug)]
 pub struct ViewPrimitive {
-    pub uniforms: Uniforms,
+    pub uniforms: DisplayUniforms,
     pub image: Option<Arc<ImageData>>,
     pub scale: f32,
     pub pan_ndc: Vec2,
@@ -33,6 +33,7 @@ pub struct ViewPrimitive {
     pub modifiers: Arc<Vec<Modifier>>,
     pub dirty: bool,
     pub pre_clear_gpu: Arc<std::sync::atomic::AtomicBool>,
+    pub reprocess_pending: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl Primitive for ViewPrimitive {
@@ -81,6 +82,8 @@ impl Primitive for ViewPrimitive {
             pipeline.update_pixel_grid(queue, &grid);
         }
         pipeline.prepare_modifiers(device, queue, &self.modifiers, self.dirty);
+        self.reprocess_pending
+            .store(pipeline.reprocess_pending(), Ordering::Release);
     }
 
     fn render(

--- a/src/wgpu/view_program.rs
+++ b/src/wgpu/view_program.rs
@@ -20,7 +20,7 @@ use crate::{
         media::image_data::ImageData,
         passes::{checkerboard::CheckerboardUniforms, pixel_grid::PixelGridUniforms},
         scale::Scale,
-        view_pipeline::Uniforms,
+        view_pipeline::DisplayUniforms,
         view_primitive::ViewPrimitive,
     },
 };
@@ -75,11 +75,21 @@ pub struct ViewProgram {
     pub crop_tool_active: bool,
     dirty: Arc<std::sync::atomic::AtomicBool>,
     pre_clear_gpu: Arc<std::sync::atomic::AtomicBool>,
+    reprocess_pending: Arc<std::sync::atomic::AtomicBool>,
     text_raster_cache: Arc<std::sync::Mutex<Option<TextRasterCache>>>,
     eyedropper_cache: Arc<std::sync::Mutex<Option<EyedropperCache>>>,
+    staged_cache: Arc<std::sync::Mutex<Option<StagedCache>>>,
 }
 
 type TextRasterCache = (u64, u32, u32, Vec<Option<TextRaster>>);
+
+struct StagedCache {
+    key: u64,
+    w: u32,
+    pixels: Vec<u8>,
+}
+
+const STAGED_EYEDROPPER_MAX_PX: u64 = 8_000_000;
 
 struct EyedropperCache {
     key: u64,
@@ -116,8 +126,10 @@ impl Default for ViewProgram {
             crop_tool_active: false,
             dirty: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             pre_clear_gpu: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            reprocess_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             text_raster_cache: Arc::new(std::sync::Mutex::new(None)),
             eyedropper_cache: Arc::new(std::sync::Mutex::new(None)),
+            staged_cache: Arc::new(std::sync::Mutex::new(None)),
         }
     }
 }
@@ -125,6 +137,11 @@ impl Default for ViewProgram {
 impl ViewProgram {
     pub fn mark_dirty(&self) {
         self.dirty.store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    pub fn reprocess_pending(&self) -> bool {
+        self.reprocess_pending
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     pub fn modifiers_mut(&mut self) -> &mut Vec<Modifier> {
@@ -554,17 +571,57 @@ impl ViewProgram {
         uv: [f32; 2],
     ) -> Option<[u8; 4]> {
         let image = self.image.as_ref()?;
-        let idx = (py as usize * image.width as usize + px as usize) * 4;
+        let w = image.width;
+        let h = image.height;
+
+        if (w as u64) * (h as u64) <= STAGED_EYEDROPPER_MAX_PX {
+            if let Some(c) = self.staged_pixel(text_layers, image, px, py) {
+                return Some(c);
+            }
+        }
+
+        let idx = (py as usize * w as usize + px as usize) * 4;
         let pixels = image.pixels_snapshot();
         let p = pixels.get(idx..idx + 4)?;
         Some(cpu::f32_to_pixel(self.apply_modifiers_cpu(
             text_layers,
             &pixels,
-            image.width,
-            image.height,
+            w,
+            h,
             uv,
             cpu::pixel_to_f32(p),
         )))
+    }
+
+    fn staged_pixel(
+        &self,
+        text_layers: &[Option<TextRaster>],
+        image: &ImageData,
+        px: u32,
+        py: u32,
+    ) -> Option<[u8; 4]> {
+        let (w, h) = (image.width, image.height);
+        let key = {
+            let mut hasher = DefaultHasher::new();
+            image.id.hash(&mut hasher);
+            hash_modifiers(&self.modifiers).hash(&mut hasher);
+            hasher.finish()
+        };
+        let mut guard = self.staged_cache.lock().unwrap_or_else(|e| e.into_inner());
+        let stale = guard.as_ref().map(|c| c.key != key).unwrap_or(true);
+        if stale {
+            let pixels = image.pixels_snapshot();
+            let staged = cpu::render_full(&self.modifiers, text_layers, &pixels, w, h);
+            *guard = Some(StagedCache {
+                key,
+                w,
+                pixels: staged,
+            });
+        }
+        let cache = guard.as_ref()?;
+        let idx = (py as usize * cache.w as usize + px as usize) * 4;
+        let p = cache.pixels.get(idx..idx + 4)?;
+        Some([p[0], p[1], p[2], p[3]])
     }
 
     pub fn color_at_window(&self, window_pos: Vec2) -> Option<[u8; 4]> {
@@ -828,7 +885,7 @@ impl Program<Message> for ViewProgram {
         let pan_ndc = self.offset / viewport;
 
         ViewPrimitive {
-            uniforms: Uniforms {
+            uniforms: DisplayUniforms {
                 transform: self.build_transform(viewport),
                 crop_uv: self.active_crop().unwrap_or([0.0, 0.0, 1.0, 1.0]),
             },
@@ -845,6 +902,7 @@ impl Program<Message> for ViewProgram {
             modifiers: self.modifiers.clone(),
             dirty: self.dirty.swap(false, std::sync::atomic::Ordering::AcqRel),
             pre_clear_gpu: Arc::clone(&self.pre_clear_gpu),
+            reprocess_pending: Arc::clone(&self.reprocess_pending),
         }
     }
 


### PR DESCRIPTION
## Modifier Engine: Executor Unification + Effect-Class Abstraction + Fixes

**Effect-class abstraction**
- Replaced `ExecModel` with an `InputRequest` contract (`SamplePoint`/`Neighborhood`/`ScanLines`/`FullFrame`) that effects author
- Added an `EffectClass` tier layer (`Pointwise`/`Fragment`/`Separable`/`ComputeScanline`) derived from `InputRequest`; all pipeline *classification* now routes through `effect_class()` instead of matching concrete `ModifierKind` variants
- Only execution/resource sites still name concrete variants (they need `ca.amount`/`ps.threshold`/glyph data) — adding a new fragment-tier effect needs zero pipeline edits
- Pinned the classification contract with a test (`class_matches_input_request_partition`); byte-identical to the prior name-matching (golden + GPU oracles unchanged)

**Executor**
- Merged 3 hand-written executors into one `prepare_tiled`; extracted shared `run_ordinary_step`
- Removed the priority-routing if-ladder; renamed ping-pong banks `bank_a`/`bank_b`

**Bug fixes (multi-tile / large images)**
- Fixed `[Blur, PixelSort]` rendering blank — both effects now apply
- Fixed tile seams on `[Blur, PixelSort]` (apron-aware blur + complete sort scan lines)
- Fixed `[Blur, Sort]` hitching and `[PixelSort, Text, Blur]` freeze (cross-frame continuation now handles mid-chain sorts)
- Removed a redundant passthrough copy before every blur pass

**Resources**
- Fixed CA + blur freeze when zoomed into huge images (VRAM-budget downscaling on the non-ROI path)
- Unified duplicate VRAM budgets into one `fit_process_scale`; made the budget adapter-aware (`max_buffer_size`, clamped 512MB–4GB)

**UI**
- Blur radius uses an unbounded number entry instead of a clamped slider

**Cleanup / conventions**
- Normalized shader uniform naming (`u` / `<Name>Uniforms`, proc/src rects); renamed `Uniforms`→`DisplayUniforms`, `Params`→`PixelSortUniforms`
- Stripped comments, removed dead code/debris

**CI**
- Added `cargo test` to CI (was lint-only); fixed `cargo fmt` failures

**Known limitations**
- `[PixelSort, Text, Blur]` zoom is improved but not fully smooth
- `[Sort, Blur]` preview blur is approximate at downscale (export is exact)

**Decoder**
- Replaced `psd` with `zune-psd` to support u16
